### PR TITLE
[BTFSINFRA-260] fix: Update analytics.go dataServeURL to URL instead of IP Address

### DIFF
--- a/analytics/analytics.go
+++ b/analytics/analytics.go
@@ -44,7 +44,7 @@ const kilobyte = 1024
 var heartBeat = 15 * time.Minute
 
 //Server URL for data collection
-var dataServeURL = "http://18.220.204.165:8080/metrics"
+var dataServeURL = "https://db.btfs.io/metrics"
 
 //Go doesn't have a built in Max function? simple function to not have negatives values
 func valOrZero(x uint64) uint64 {


### PR DESCRIPTION
The purpose of this PR is to update var dataServeURL to "https://db.btfs.io/metrics" instead of "http://18.220.204.165:8080/metrics".