### PR TITLE
docker: fix build when running under a submodule folder

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 Dockerfile
 Dockerfile.fast
+.git
 .git/
 !.git/HEAD
 !.git/refs/

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,13 @@ RUN cd $SRC_DIR \
 
 COPY . $SRC_DIR
 
+# Newer git submodule uses "absorbgitdirs" option by default which does not
+# include .git folder inside a submodule.
+# Use a build time variable $gitdir to specify the location of the actual .git folder.
+ARG gitdir=.git
+RUN test -d $SRC_DIR/.git \
+  || mv $SRC_DIR/$gitdir $SRC_DIR/.git
+
 # Install path
 RUN apt-get update && apt-get install -y patch
 


### PR DESCRIPTION
Newer git submodule uses "absorbgitdirs" option by default which does not include .git folder inside a submodule.

Use a build time variable $gitdir to specify the location of the actual .git folder.