### PR TITLE
Delete the LICENSE-APACHE file

### DIFF
--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -1,5 +1,0 @@
-Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
-
-http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.


### PR DESCRIPTION
This license file is not used in BTFS. BTFS is in MIT license.