### PR TITLE
[BTFSINFRA-370] fix key gen type

### DIFF
--- a/core/commands/keystore.go
+++ b/core/commands/keystore.go
@@ -63,7 +63,7 @@ var keyGenCmd = &cmds.Command{
 		Tagline: "Create a new keypair",
 	},
 	Options: []cmds.Option{
-		cmds.StringOption(keyStoreTypeOptionName, "t", "type of the key to create [rsa, ed25519]"),
+		cmds.StringOption(keyStoreTypeOptionName, "t", "type of the key to create [rsa, ed25519, ecdsa]"),
 		cmds.IntOption(keyStoreSizeOptionName, "s", "size of the key to generate"),
 	},
 	Arguments: []cmds.Argument{


### PR DESCRIPTION
add ecdsa to the list of types allowed 
