### PR TITLE
Add public IP to config when btfs init and in new announce-public pro…

### DIFF
--- a/cmd/btfs/init.go
+++ b/cmd/btfs/init.go
@@ -270,11 +270,20 @@ func addDefaultAssets(out io.Writer, repoRoot string) error {
 		return err
 	}
 
-	nd, err := core.NewNode(ctx, &core.BuildCfg{Repo: r})
+	buildCfg := &core.BuildCfg{Repo: r}
+	nd, err := core.NewNode(ctx, buildCfg)
 	if err != nil {
 		return err
 	}
 	defer nd.Close()
+
+	// announce public ip by default for btfs nodes running on cloud vm
+	// or local network with NAT
+	err = buildCfg.AnnouncePublicIp()
+	if err != nil {
+		// don't quit here, user can manually add to config later
+		fmt.Fprintf(out, "announce public ip failed.\n")
+	}
 
 	dkey, err := assets.SeedInitDocs(nd)
 	if err != nil {

--- a/docs/config.md
+++ b/docs/config.md
@@ -34,6 +34,10 @@ Available profiles:
 
   Restores default network settings. Inverse profile of the `test` profile.
 
+- `announce-public`
+
+  Announce public IP when running on cloud VM or local network.
+
 - `badgerds`
 
   Replaces default datastore configuration with experimental badger datastore.

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/TRON-US/go-btfs
 
 require (
 	bazil.org/fuse v0.0.0-20180421153158-65cc252bf669
+	github.com/FactomProject/basen v0.0.0-20150613233007-fe3947df716e // indirect
+	github.com/FactomProject/btcutilecc v0.0.0-20130527213604-d3a63a5752ec // indirect
 	github.com/Kubuxu/go-os-helper v0.0.1
 	github.com/Kubuxu/gocovmerge v0.0.0-20161216165753-7ecaa51963cd
 	github.com/StackExchange/wmi v0.0.0-20181212234831-e0a55b97c705 // indirect
@@ -116,6 +118,8 @@ require (
 	github.com/prometheus/procfs v0.0.0-20190519111021-9935e8e0588d // indirect
 	github.com/shirou/gopsutil v2.18.12+incompatible
 	github.com/syndtr/goleveldb v1.0.0
+	github.com/tyler-smith/go-bip32 v0.0.0-20170922074101-2c9cfd177564
+	github.com/tyler-smith/go-bip39 v1.0.0
 	github.com/whyrusleeping/base32 v0.0.0-20170828182744-c30ac30633cc
 	github.com/whyrusleeping/go-sysinfo v0.0.0-20190219211824-4a357d4b90b1
 	github.com/whyrusleeping/multiaddr-filter v0.0.0-20160516205228-e903e4adabd7

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,10 @@ github.com/AndreasBriese/bbloom v0.0.0-20180913140656-343706a395b7 h1:PqzgE6kAMi
 github.com/AndreasBriese/bbloom v0.0.0-20180913140656-343706a395b7/go.mod h1:bOvUY6CB00SOBii9/FifXqc0awNKxLFCL/+pkDPuyl8=
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/FactomProject/basen v0.0.0-20150613233007-fe3947df716e h1:ahyvB3q25YnZWly5Gq1ekg6jcmWaGj/vG/MhF4aisoc=
+github.com/FactomProject/basen v0.0.0-20150613233007-fe3947df716e/go.mod h1:kGUqhHd//musdITWjFvNTHn90WG9bMLBEPQZ17Cmlpw=
+github.com/FactomProject/btcutilecc v0.0.0-20130527213604-d3a63a5752ec h1:1Qb69mGp/UtRPn422BH4/Y4Q3SLUrD9KHuDkm8iodFc=
+github.com/FactomProject/btcutilecc v0.0.0-20130527213604-d3a63a5752ec/go.mod h1:CD8UlnlLDiqb36L110uqiP2iSflVjx9g/3U9hCI4q2U=
 github.com/Kubuxu/go-os-helper v0.0.1 h1:EJiD2VUQyh5A9hWJLmc6iWg6yIcJ7jpBcwC8GMGXfDk=
 github.com/Kubuxu/go-os-helper v0.0.1/go.mod h1:N8B+I7vPCT80IcP58r50u4+gEEcsZETFUpAzWW2ep1Y=
 github.com/Kubuxu/gocovmerge v0.0.0-20161216165753-7ecaa51963cd h1:HNhzThEtZW714v8Eda8sWWRcu9WSzJC+oCyjRjvZgRA=
@@ -736,6 +740,10 @@ github.com/syndtr/goleveldb v1.0.0 h1:fBdIW9lB4Iz0n9khmH8w27SJ3QEJ7+IgjPEwGSZiFd
 github.com/syndtr/goleveldb v1.0.0/go.mod h1:ZVVdQEZoIme9iO1Ch2Jdy24qqXrMMOU6lpPAyBWyWuQ=
 github.com/texttheater/golang-levenshtein v0.0.0-20180516184445-d188e65d659e h1:T5PdfK/M1xyrHwynxMIVMWLS7f/qHwfslZphxtGnw7s=
 github.com/texttheater/golang-levenshtein v0.0.0-20180516184445-d188e65d659e/go.mod h1:XDKHRm5ThF8YJjx001LtgelzsoaEcvnA7lVWz9EeX3g=
+github.com/tyler-smith/go-bip32 v0.0.0-20170922074101-2c9cfd177564 h1:NXXyQVeRVLK8Xu27/hkkjwVOZLk5v4ZBEvvMtqMqznM=
+github.com/tyler-smith/go-bip32 v0.0.0-20170922074101-2c9cfd177564/go.mod h1:0/YuQQF676+d4CMNclTqGUam1EDwz0B8o03K9pQqA3c=
+github.com/tyler-smith/go-bip39 v1.0.0 h1:FOHg9gaQLeBBRbHE/QrTLfEiBHy5pQ/yXzf9JG5pYFM=
+github.com/tyler-smith/go-bip39 v1.0.0/go.mod h1:sJ5fKU0s6JVwZjjcUEX2zFOnvq0ASQ2K9Zr6cf67kNs=
 github.com/urfave/cli v1.20.0 h1:fDqGv3UG/4jbVl/QkFwEdddtEDjh/5Ov6X+0B/3bPaw=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/warpfork/go-wish v0.0.0-20180510122957-5ad1f5abf436 h1:qOpVTI+BrstcjTZLm2Yz/3sOnqkzj3FQoh0g+E5s3Gc=

--- a/patches/go-ipfs-config-v0.0.3-profile.go.patch
+++ b/patches/go-ipfs-config-v0.0.3-profile.go.patch
@@ -1,0 +1,56 @@
+--- go-ipfs-config@v0.0.3/profile.go	2019-08-02 16:16:29.000000000 -0700
++++ /tmp/go-ipfs-config/profile.go	2019-08-02 16:21:47.000000000 -0700
+@@ -3,6 +3,8 @@
+ import (
+ 	"fmt"
+ 	"net"
++	"net/http"
++	"io/ioutil"
+ 	"time"
+ )
+ 
+@@ -44,6 +46,26 @@
+ 	"/ip6/fe80::/ipcidr/10",
+ }
+ 
++func ExternalIP() (string, error) {
++        resp, err := http.Get("http://checkip.amazonaws.com")
++        if err != nil {
++                fmt.Println("get external IP failed")
++                return "", err
++        }
++        defer resp.Body.Close()
++        body, err := ioutil.ReadAll(resp.Body)
++        if err != nil {
++                fmt.Println("parse external IP failed")
++                return "", err
++        }
++        ip := string(body)
++        // remove last return
++        ip = ip[:len(ip)-1]
++        address := "/ip4/" + ip
++        address += "/tcp/4001"
++        return address, nil
++}
++
+ // Profiles is a map holding configuration transformers. Docs are in docs/config.md
+ var Profiles = map[string]Profile{
+ 	"server": {
+@@ -107,6 +129,17 @@
+ 			return nil
+ 		},
+ 	},
++	"announce-public": {
++		Description: `Announce public IP when running on cloud VM or local network.`,
++		Transform: func(c *Config) error {
++			address, err := ExternalIP()
++			if err != nil {
++				return err
++			}
++			c.Addresses.Announce = appendSingle(c.Addresses.Announce, []string{address})
++			return nil
++		},
++	},
+ 	"badgerds": {
+ 		Description: `Replaces default datastore configuration with experimental
+ badger datastore.

--- a/patching.sh
+++ b/patching.sh
@@ -55,6 +55,10 @@ fi
 if ! patch -R -s -f --dry-run $patchdir/bootstrap_peers.go < ./patches/go-ipfs-config-v0.0.3-bootstrap_peers.go.patch 1>/dev/null; then
     patch $patchdir/bootstrap_peers.go < ./patches/go-ipfs-config-v0.0.3-bootstrap_peers.go.patch;
 fi
+# 4) patching profile.go
+if ! patch -R -s -f --dry-run $patchdir/profile.go < ./patches/go-ipfs-config-v0.0.3-profile.go.patch 1>/dev/null; then
+    patch $patchdir/profile.go < ./patches/go-ipfs-config-v0.0.3-profile.go.patch
+fi
 
 # patching $GOPATH/pkg/mod/github.com/libp2p/go-libp2p-record@v0.0.1
 patchdir=$GOPATH/pkg/mod/github.com/libp2p/go-libp2p-record@v0.0.1


### PR DESCRIPTION
Public IP was added to config Addresses Announce when run btfs daemon.
In this case we cannnot run two daemon on same server because port conflict.
Now we add public IP when btfs init, also provide a new config profile to add
public IP.
  btfs config profile apply announce-public
When run "btfs config profile apply default-networking", the Announce public IP
will be deleted in config.