### PR TITLE
Implemented optin and optout commands as subcommand of config.

### DIFF
--- a/cmd/btfs/init.go
+++ b/cmd/btfs/init.go
@@ -67,7 +67,7 @@ environment variable:
 		cmds.StringOption(profileOptionName, "p", "Apply profile settings to config. Multiple profiles can be separated by ','"),
 		cmds.StringOption(keyTypeOptionName, "k", "Key generation algorithm, e.g. RSA, Ed25519, Secp256k1, ECDSA, BIP39. By default is Secp256k1"),
 		cmds.StringOption(importKeyOptionName, "i", "Import TRON private key to generate btfs PeerID."),
-		cmds.BoolOption(rmOnUnpinOptionName, "r", "Remove unpinned files."),
+		cmds.BoolOption(rmOnUnpinOptionName, "r", "Remove unpinned files.").WithDefault(false),
 		cmds.StringOption(seedOptionName, "s", "Import seed phrase"),
 
 		// TODO need to decide whether to expose the override as a file or a
@@ -195,6 +195,7 @@ func initWithDefaults(out io.Writer, repoRoot string, profile string) error {
 		profiles = strings.Split(profile, ",")
 	}
 
+	// the last argument (false) refers to the configuration variable Experimental.RemoveOnUnpin
 	return doInit(out, repoRoot, false, nBitsForKeypairDefault, profiles, nil, keyTypeDefault, "", false)
 }
 
@@ -214,7 +215,7 @@ func doInit(out io.Writer, repoRoot string, empty bool, nBitsForKeypair int, con
 
 	if conf == nil {
 		var err error
-		conf, err = config.Init(out, nBitsForKeypair, keyType, importKey)
+		conf, err = config.Init(out, nBitsForKeypair, keyType, importKey, rmOnUnpin)
 		if err != nil {
 			return err
 		}

--- a/core/commands/config.go
+++ b/core/commands/config.go
@@ -14,8 +14,8 @@ import (
 	"github.com/TRON-US/go-btfs/repo"
 	"github.com/TRON-US/go-btfs/repo/fsrepo"
 
-	"github.com/TRON-US/go-btfs-cmds"
-	"github.com/TRON-US/go-btfs-config"
+	cmds "github.com/TRON-US/go-btfs-cmds"
+	config "github.com/TRON-US/go-btfs-config"
 	"github.com/elgris/jsondiff"
 )
 
@@ -64,6 +64,8 @@ Set the value of the 'Datastore.Path' key:
 		"edit":    configEditCmd,
 		"replace": configReplaceCmd,
 		"profile": configProfileCmd,
+		"optin":   optInCmd,
+		"optout":  optOutCmd,
 	},
 	Arguments: []cmds.Argument{
 		cmds.StringArg("key", true, false, "The key of the config entry (e.g. \"Addresses.API\")."),
@@ -355,6 +357,104 @@ var configProfileApplyCmd = &cmds.Command{
 		}),
 	},
 	Type: ConfigUpdateOutput{},
+}
+
+var optInCmd = &cmds.Command{
+	Helptext: cmds.HelpText{
+		Tagline:          "Opt-in enables analytic data collection (default).",
+		ShortDescription: `To change the setting (to opt-out), execute 'btfs config optout'.`,
+		LongDescription: `
+'btfs config optin' controls configuration variable 'Experimental.Analytics'.
+By setting the configuration value to 'true', you agree to the collection of the following data:
+1. A random, generated BTFS Node ID
+2. Aggregate Node Uptime
+3. BTFS version; e.g. 0.1.0
+4. OS Type
+5. CPU Architecture Type
+6. Node GPS location (longitute, latitude)
+`,
+	},
+
+	Run: func(req *cmds.Request, res cmds.ResponseEmitter, env cmds.Environment) error {
+		n, err := cmdenv.GetNode(env)
+		if err != nil {
+			return err
+		}
+
+		config, err := n.Repo.Config()
+		if err != nil {
+			return err
+		}
+
+		config.Experimental.Analytics = true
+
+		var output *ConfigField
+
+		cfgRoot, err := cmdenv.GetConfigRoot(env)
+		if err != nil {
+			return err
+		}
+		r, err := fsrepo.Open(cfgRoot)
+		if err != nil {
+			return err
+		}
+
+		output, err = setConfig(r, "Experimental.Analytics", true)
+		if err != nil {
+			return err
+		}
+
+		return cmds.EmitOnce(res, output)
+	},
+}
+
+var optOutCmd = &cmds.Command{
+	Helptext: cmds.HelpText{
+		Tagline:          "Opt-out disables collection of the analytics data (enabled by default).",
+		ShortDescription: `In order to opt out of the collection of analytics data, execute 'btfs config optout.`,
+		LongDescription: `
+'btfs config optout' controls configuration variable 'Experimental.Analytics'.
+By setting the configuration value to 'false', you disable the collection of the following analytics data:
+1. A random, generated BTFS Node ID
+2. Aggregate Node Uptime
+3. BTFS version; e.g. 0.1.0
+4. OS Type
+5. CPU Architecture Type
+6. Node GPS location (longitute, latitude)
+`,
+	},
+
+	Run: func(req *cmds.Request, res cmds.ResponseEmitter, env cmds.Environment) error {
+		n, err := cmdenv.GetNode(env)
+		if err != nil {
+			return err
+		}
+
+		config, err := n.Repo.Config()
+		if err != nil {
+			return err
+		}
+
+		config.Experimental.Analytics = false
+
+		var output *ConfigField
+
+		cfgRoot, err := cmdenv.GetConfigRoot(env)
+		if err != nil {
+			return err
+		}
+		r, err := fsrepo.Open(cfgRoot)
+		if err != nil {
+			return err
+		}
+
+		output, err = setConfig(r, "Experimental.Analytics", false)
+		if err != nil {
+			return err
+		}
+
+		return cmds.EmitOnce(res, output)
+	},
 }
 
 func buildProfileHelp() string {

--- a/core/commands/pin.go
+++ b/core/commands/pin.go
@@ -2,11 +2,9 @@ package commands
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"os"
-	"strconv"
 	"time"
 
 	cmds "github.com/TRON-US/go-btfs-cmds"
@@ -222,17 +220,6 @@ collected if needed. (By default, recursively. Use -r=false for direct pins.)
 			return err
 		}
 
-		var rmOnUnpin bool = false
-
-		var m map[string]string
-		if cfg.Datastore.Params != nil {
-			if err := json.Unmarshal(*cfg.Datastore.Params, &m); err != nil {
-				fmt.Println(err)
-			}
-		}
-
-		rmOnUnpin, _ = strconv.ParseBool(m["rmOnUnpin"])
-
 		api, err := cmdenv.GetApi(env, req)
 		if err != nil {
 			return err
@@ -269,7 +256,7 @@ collected if needed. (By default, recursively. Use -r=false for direct pins.)
 			return err
 		}
 
-		if rmOnUnpin {
+		if cfg.Experimental.RemoveOnUnpin {
 			RepoCmd.Subcommands["gc"].Run(req, res, env)
 		}
 


### PR DESCRIPTION
**This PR introduces a feature to opt-in and opt-out of analytic data collection.**

Submitted changes include:

**config.go**
Config command is modified, and introduces two new subcommands: optin, and optout.

**Optin** modifies the in-memory stored configuration (within repo object), and is used for life change. In addition, the file system repo is changed (config file is updated), making the change persistent. Upon successive launch of the deamon, the state of the configuration variable Experimental. Analytics is the same as before daemon terminated.

**Optout** performs operation opposite to optin. It disables collection and storing of analytic information.

**pin.go**
Introduces the usage of RemoveOnUnpin configuration variable.

**init.go**
Sets the RemoveOnUnpin variable to false by default.

**analytics.go**
The configuration variable Experimental.Analytics is read during initialization. If set to “true,” The analytic data is collected and set out to status-server. In the for loop running at heartbeat intervals (currently set to 15 minutes), the configuration is checked. It allows a user to dynamically optin and optout of the collection and sending of the analytics.

**Usage:**
Regardless of whether the daemon is running or not, execute:
`btfs config optout` - to opt out
`btfs config optin` - to opt in