### PR TITLE
Added seed phrase checking.

### DIFF
--- a/cmd/btfs/init.go
+++ b/cmd/btfs/init.go
@@ -136,7 +136,10 @@ environment variable:
 			return fmt.Errorf("cannot specify key type and import TRON private key at the same time")
 		} else if seedPhrase != "" {
 			if mnemonicLen != mnemonicLength {
-				return fmt.Errorf("mnemonic needs to contain 12 words")
+				return fmt.Errorf("The seed phrase required to generate TRON private key needs to contain 12 words. Provided mnemonic has %v words.", mnemonicLen)
+			}
+			if err := !bip39.IsMnemonicValid(mnemonic); err {
+				return fmt.Errorf("Entered seed phrase is not valid")
 			}
 			fmt.Println("Generating TRON key with BIP39 seed phrase...")
 			importKey = generatePrivKeyUsingBIP39(mnemonic)


### PR DESCRIPTION
**PR**:
This PR introduces changes to the validation of the seed phrase.

**Check 1:**
In order to accomplish TronLink compatibility, the seed phrase requires 128bit entropy, which translates into 12 words. The first check is therefore ensuring proper seed phrase length.

**Check 2:**
The words in the seed phrase need to come from BIP39 english dictionary. This check accomplishes that.

**Error messages:**
Check 1 returns an error indicating wrong number of words in the seed phrase. Assuming there were 11 words in the seed phrase, the corresponding error message would be "The seed phrase required to generate TRON private key needs to contain 12 words. Provided mnemonic has 11 words."

Check 2 returns an error indicating the invalidity of the seed phrase. Assuming that the following seed phrase is not valid "abandon,ability,able,about,above,absent,absorb,access,abuse,accident,accuse,acidity", the corresponding message would be "Entered seed phrase is not valid."