### PR TITLE
[BTFSINFRA-449] add a daemon flag to enable/disable data collecion

### DIFF
--- a/analytics/analytics.go
+++ b/analytics/analytics.go
@@ -84,7 +84,6 @@ func durationToSeconds(duration time.Duration) uint64 {
 //Initialize starts the process to collect data and starts the GoRoutine for constant collection
 func Initialize(n *core.IpfsNode, BTFSVersion string) {
 	var log = logging.Logger("cmd/btfs")
-	configuration, err := n.Repo.Config()
 	if err != nil {
 		return
 	}
@@ -92,20 +91,18 @@ func Initialize(n *core.IpfsNode, BTFSVersion string) {
 	dc := new(dataCollection)
 	dc.node = n
 
-	if configuration.Experimental.Analytics {
-		infoStats, err := cpu.Info()
-		if err == nil {
-			dc.CPUInfo = infoStats[0].ModelName
-		} else {
-			log.Warning(err.Error())
-		}
-
-		dc.startTime = time.Now()
-		dc.NodeID = n.Identity.Pretty()
-		dc.BTFSVersion = BTFSVersion
-		dc.OSType = runtime.GOOS
-		dc.ArchType = runtime.GOARCH
+	infoStats, err := cpu.Info()
+	if err == nil {
+		dc.CPUInfo = infoStats[0].ModelName
+	} else {
+		log.Warning(err.Error())
 	}
+
+	dc.startTime = time.Now()
+	dc.NodeID = n.Identity.Pretty()
+	dc.BTFSVersion = BTFSVersion
+	dc.OSType = runtime.GOOS
+	dc.ArchType = runtime.GOARCH
 
 	go dc.collectionAgent()
 }

--- a/analytics/analytics.go
+++ b/analytics/analytics.go
@@ -142,7 +142,6 @@ func (dc *dataCollection) update() {
 }
 
 func (dc *dataCollection) sendData() {
-	fmt.Println("Data Sent")
 	dc.update()
 	dcMarshal, err := json.Marshal(dc)
 	if err != nil {

--- a/analytics/analytics.go
+++ b/analytics/analytics.go
@@ -84,9 +84,6 @@ func durationToSeconds(duration time.Duration) uint64 {
 //Initialize starts the process to collect data and starts the GoRoutine for constant collection
 func Initialize(n *core.IpfsNode, BTFSVersion string) {
 	var log = logging.Logger("cmd/btfs")
-	if err != nil {
-		return
-	}
 
 	dc := new(dataCollection)
 	dc.node = n
@@ -145,6 +142,7 @@ func (dc *dataCollection) update() {
 }
 
 func (dc *dataCollection) sendData() {
+	fmt.Println("Data Sent")
 	dc.update()
 	dcMarshal, err := json.Marshal(dc)
 	if err != nil {
@@ -192,18 +190,10 @@ func (dc *dataCollection) collectionAgent() {
 
 	defer tick.Stop()
 
-	config, _ := dc.node.Repo.Config()
-	if config.Experimental.Analytics {
-		dc.sendData()
-	}
+	dc.sendData()
 	// make the configuration available in the for loop
 	for range tick.C {
-		config, _ := dc.node.Repo.Config()
-		// check config for explicit consent to data collect
-		// consent can be changed without reinitializing data collection
-		if config.Experimental.Analytics {
-			dc.sendData()
-		}
+		dc.sendData()
 	}
 }
 

--- a/cmd/btfs/daemon.go
+++ b/cmd/btfs/daemon.go
@@ -426,10 +426,7 @@ func daemonFunc(req *cmds.Request, re cmds.ResponseEmitter, env cmds.Environment
 	//Begin sending analytics to hosted server
 	collectData, _ := req.Options[enableDataCollection].(bool)
 	if collectData {
-		fmt.Println("Collecting Data")
 		analytics.Initialize(node, version.CurrentVersionNumber)
-	} else {
-		fmt.Println("Not Collectng Data")
 	}
 
 	// Give the user some immediate feedback when they hit C-c

--- a/cmd/btfs/daemon.go
+++ b/cmd/btfs/daemon.go
@@ -59,6 +59,7 @@ const (
 	enablePubSubKwd           = "enable-pubsub-experiment"
 	enableIPNSPubSubKwd       = "enable-namesys-pubsub"
 	enableMultiplexKwd        = "enable-mplex-experiment"
+	enableDataCollection      = "enable-data-collection"
 	// apiAddrKwd    = "address-api"
 	// swarmAddrKwd  = "address-swarm"
 )
@@ -171,6 +172,7 @@ Headers.
 		cmds.BoolOption(enablePubSubKwd, "Instantiate the btfs daemon with the experimental pubsub feature enabled."),
 		cmds.BoolOption(enableIPNSPubSubKwd, "Enable BTNS record distribution through pubsub; enables pubsub."),
 		cmds.BoolOption(enableMultiplexKwd, "Add the experimental 'go-multiplex' stream muxer to libp2p on construction.").WithDefault(true),
+		cmds.BoolOption(enableDataCollection, "Allow BTFS to collect and send out node statistics."),
 
 		// TODO: add way to override addresses. tricky part: updating the config if also --init.
 		// cmds.StringOption(apiAddrKwd, "Address for the daemon rpc API (overrides config)"),
@@ -422,7 +424,10 @@ func daemonFunc(req *cmds.Request, re cmds.ResponseEmitter, env cmds.Environment
 	fmt.Printf("Daemon is ready\n")
 
 	//Begin sending analytics to hosted server
-	analytics.Initialize(node, version.CurrentVersionNumber)
+	collectData, _ := req.Options[enableDataCollection].(bool)
+	if collectData {
+		analytics.Initialize(node, version.CurrentVersionNumber)
+	}
 
 	// Give the user some immediate feedback when they hit C-c
 	go func() {

--- a/cmd/btfs/daemon.go
+++ b/cmd/btfs/daemon.go
@@ -426,7 +426,10 @@ func daemonFunc(req *cmds.Request, re cmds.ResponseEmitter, env cmds.Environment
 	//Begin sending analytics to hosted server
 	collectData, _ := req.Options[enableDataCollection].(bool)
 	if collectData {
+		fmt.Println("Collecting Data")
 		analytics.Initialize(node, version.CurrentVersionNumber)
+	} else {
+		fmt.Println("Not Collectng Data")
 	}
 
 	// Give the user some immediate feedback when they hit C-c

--- a/core/commands/config.go
+++ b/core/commands/config.go
@@ -14,8 +14,6 @@ import (
 	"github.com/TRON-US/go-btfs/repo"
 	"github.com/TRON-US/go-btfs/repo/fsrepo"
 
-	cmds "github.com/TRON-US/go-btfs-cmds"
-	config "github.com/TRON-US/go-btfs-config"
 	"github.com/elgris/jsondiff"
 )
 
@@ -64,8 +62,6 @@ Set the value of the 'Datastore.Path' key:
 		"edit":    configEditCmd,
 		"replace": configReplaceCmd,
 		"profile": configProfileCmd,
-		"optin":   optInCmd,
-		"optout":  optOutCmd,
 	},
 	Arguments: []cmds.Argument{
 		cmds.StringArg("key", true, false, "The key of the config entry (e.g. \"Addresses.API\")."),
@@ -357,104 +353,6 @@ var configProfileApplyCmd = &cmds.Command{
 		}),
 	},
 	Type: ConfigUpdateOutput{},
-}
-
-var optInCmd = &cmds.Command{
-	Helptext: cmds.HelpText{
-		Tagline:          "Opt-in enables analytic data collection (default).",
-		ShortDescription: `To change the setting (to opt-out), execute 'btfs config optout'.`,
-		LongDescription: `
-'btfs config optin' controls configuration variable 'Experimental.Analytics'.
-By setting the configuration value to 'true', you agree to the collection of the following data:
-1. A random, generated BTFS Node ID
-2. Aggregate Node Uptime
-3. BTFS version; e.g. 0.1.0
-4. OS Type
-5. CPU Architecture Type
-6. Node GPS location (longitute, latitude)
-`,
-	},
-
-	Run: func(req *cmds.Request, res cmds.ResponseEmitter, env cmds.Environment) error {
-		n, err := cmdenv.GetNode(env)
-		if err != nil {
-			return err
-		}
-
-		config, err := n.Repo.Config()
-		if err != nil {
-			return err
-		}
-
-		config.Experimental.Analytics = true
-
-		var output *ConfigField
-
-		cfgRoot, err := cmdenv.GetConfigRoot(env)
-		if err != nil {
-			return err
-		}
-		r, err := fsrepo.Open(cfgRoot)
-		if err != nil {
-			return err
-		}
-
-		output, err = setConfig(r, "Experimental.Analytics", true)
-		if err != nil {
-			return err
-		}
-
-		return cmds.EmitOnce(res, output)
-	},
-}
-
-var optOutCmd = &cmds.Command{
-	Helptext: cmds.HelpText{
-		Tagline:          "Opt-out disables collection of the analytics data (enabled by default).",
-		ShortDescription: `In order to opt out of the collection of analytics data, execute 'btfs config optout.`,
-		LongDescription: `
-'btfs config optout' controls configuration variable 'Experimental.Analytics'.
-By setting the configuration value to 'false', you disable the collection of the following analytics data:
-1. A random, generated BTFS Node ID
-2. Aggregate Node Uptime
-3. BTFS version; e.g. 0.1.0
-4. OS Type
-5. CPU Architecture Type
-6. Node GPS location (longitute, latitude)
-`,
-	},
-
-	Run: func(req *cmds.Request, res cmds.ResponseEmitter, env cmds.Environment) error {
-		n, err := cmdenv.GetNode(env)
-		if err != nil {
-			return err
-		}
-
-		config, err := n.Repo.Config()
-		if err != nil {
-			return err
-		}
-
-		config.Experimental.Analytics = false
-
-		var output *ConfigField
-
-		cfgRoot, err := cmdenv.GetConfigRoot(env)
-		if err != nil {
-			return err
-		}
-		r, err := fsrepo.Open(cfgRoot)
-		if err != nil {
-			return err
-		}
-
-		output, err = setConfig(r, "Experimental.Analytics", false)
-		if err != nil {
-			return err
-		}
-
-		return cmds.EmitOnce(res, output)
-	},
 }
 
 func buildProfileHelp() string {

--- a/core/commands/config.go
+++ b/core/commands/config.go
@@ -14,6 +14,9 @@ import (
 	"github.com/TRON-US/go-btfs/repo"
 	"github.com/TRON-US/go-btfs/repo/fsrepo"
 
+	cmds "github.com/TRON-US/go-btfs-cmds"
+	config "github.com/TRON-US/go-btfs-config"
+
 	"github.com/elgris/jsondiff"
 )
 


### PR DESCRIPTION

allow to pass in flag to enable and disable data collection  \
remove the implementation that uses config sub command
example usage: 
btfs daemon -enable-data-collection=false
btfs daemon -enable-data-collection=true