### PR TITLE
[BTFSINFRA-449] allow daemon to change and persist data collection change

### DIFF
--- a/cmd/btfs/daemon.go
+++ b/cmd/btfs/daemon.go
@@ -59,6 +59,7 @@ const (
 	enablePubSubKwd           = "enable-pubsub-experiment"
 	enableIPNSPubSubKwd       = "enable-namesys-pubsub"
 	enableMultiplexKwd        = "enable-mplex-experiment"
+	enableDataCollection      = "enable-data-collection"
 	// apiAddrKwd    = "address-api"
 	// swarmAddrKwd  = "address-swarm"
 )
@@ -171,6 +172,7 @@ Headers.
 		cmds.BoolOption(enablePubSubKwd, "Instantiate the btfs daemon with the experimental pubsub feature enabled."),
 		cmds.BoolOption(enableIPNSPubSubKwd, "Enable BTNS record distribution through pubsub; enables pubsub."),
 		cmds.BoolOption(enableMultiplexKwd, "Add the experimental 'go-multiplex' stream muxer to libp2p on construction.").WithDefault(true),
+		cmds.BoolOption(enableDataCollection, "Allow BTFS to collect and send out node statistics."),
 
 		// TODO: add way to override addresses. tricky part: updating the config if also --init.
 		// cmds.StringOption(apiAddrKwd, "Address for the daemon rpc API (overrides config)"),
@@ -422,6 +424,8 @@ func daemonFunc(req *cmds.Request, re cmds.ResponseEmitter, env cmds.Environment
 	fmt.Printf("Daemon is ready\n")
 
 	//Begin sending analytics to hosted server
+	collectData, _ := req.Options[enableDataCollection].(bool)
+	node.Repo.SetConfigKey("Experimental.Analytics", collectData)
 	analytics.Initialize(node, version.CurrentVersionNumber)
 
 	// Give the user some immediate feedback when they hit C-c


### PR DESCRIPTION
added an option enable-data-collection to btfs daemon.  usage

btfs daemon -enable-data-collection=true or btfs daemon -enable-data-collection=false

it will also persist to the configuration file 