### PR TITLE
BTFSINFRA-408 DO NOT MERGE send status server metrics many times per second

### DIFF
--- a/analytics/analytics.go
+++ b/analytics/analytics.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/http/httputil"
 	"runtime"
 	"time"
 
@@ -65,7 +66,11 @@ const (
 	kilobyte = 1024
 
 	//HeartBeat is how often we send data to server, at the moment set to 15 Minutes
-	heartBeat = 15 * time.Minute
+	//heartBeat = 15 * time.Minute
+	//heartBeat is changed to each second for load test
+	heartBeat = 1 * time.Second
+	//repeats is the number of extra times to send data for the load test
+	repeats   = 5
 )
 
 //Go doesn't have a built in Max function? simple function to not have negatives values
@@ -190,6 +195,19 @@ func (dc *dataCollection) sendData() {
 		dc.reportHealthAlert(fmt.Sprintf("failed to make new http request: %s", err.Error()))
 		return
 	}
+
+	// print time
+	t := time.Now()
+	fmt.Println(t.Format("2006-01-02 15:04:05.999999999"))
+
+	// Save a copy of this request for debugging.
+	requestDump, err := httputil.DumpRequest(req, true)
+	if err != nil {
+		fmt.Println(err)
+	}
+	fmt.Println(string(requestDump))
+	fmt.Sprintf("hostname is: : %s", statusServerDomain)
+
 	req.Header.Add("Content-Type", "application/json")
 
 	res, err := http.DefaultClient.Do(req)
@@ -209,12 +227,11 @@ func (dc *dataCollection) collectionAgent() {
 	if config.Experimental.Analytics {
 		dc.sendData()
 	}
-	// make the configuration available in the for loop
 	for range tick.C {
-		config, _ := dc.node.Repo.Config()
-		// check config for explicit consent to data collect
-		// consent can be changed without reinitializing data collection
-		if config.Experimental.Analytics {
+		fmt.Println("== in inner range tick.C ==")
+		// repeat sending data for load test
+		for i := 1; i <= repeats; i++ {
+			fmt.Print("=== repeating ", i, " ===\n")
 			dc.sendData()
 		}
 	}

--- a/analytics/analytics.go
+++ b/analytics/analytics.go
@@ -117,7 +117,6 @@ func Initialize(n *core.IpfsNode, BTFSVersion string) {
 		dc.OSType = runtime.GOOS
 		dc.ArchType = runtime.GOARCH
 	}
-
 	go dc.collectionAgent()
 }
 
@@ -198,7 +197,11 @@ func (dc *dataCollection) sendData() {
 
 	// print time
 	t := time.Now()
-	fmt.Println(t.Format("2006-01-02 15:04:05.999999999"))
+	fmt.Println("===", t.Format("2006-01-02 15:04:05.999999999"))
+	fmt.Println("=== Sending data collection")
+	fmt.Println("=== Hostname is: ", statusServerDomain)
+
+	req.Header.Add("Content-Type", "application/json")
 
 	// Save a copy of this request for debugging.
 	requestDump, err := httputil.DumpRequest(req, true)
@@ -206,9 +209,7 @@ func (dc *dataCollection) sendData() {
 		fmt.Println(err)
 	}
 	fmt.Println(string(requestDump))
-	fmt.Sprintf("hostname is: : %s", statusServerDomain)
 
-	req.Header.Add("Content-Type", "application/json")
 
 	res, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -252,6 +253,16 @@ func (dc *dataCollection) reportHealthAlert(failurePoint string) {
 	}
 	req, err := http.NewRequest("POST", fmt.Sprintf("%s%s", statusServerDomain, routeHealth), bytes.NewReader(hdMarshaled))
 	req.Header.Add("Content-Type", "application/json")
+
+	t := time.Now()
+	fmt.Println("=== ", t.Format("2006-01-02 15:04:05.999999999"))
+	fmt.Println("=== Sending routeHealth")
+	// Save a copy of this request for debugging.
+	requestDump, err := httputil.DumpRequest(req, true)
+	if err != nil {
+		fmt.Println(err)
+	}
+	fmt.Println(string(requestDump))
 
 	res, err := http.DefaultClient.Do(req)
 	if err != nil {


### PR DESCRIPTION
this branch is for a load test of the status server.  go-btfs will send metrics 3-4 times a second instead of 1 time every 15 mins.  3-4 times a second is the fastest my laptop can encrypt the metric payload to send over to the status server.