### PR TITLE
[BTFSINFRA-522] Funtest flag

### DIFF
--- a/cmd/btfs/daemon.go
+++ b/cmd/btfs/daemon.go
@@ -187,7 +187,6 @@ Headers.
 		cmds.BoolOption(enableDataCollection, "Allow BTFS to collect and send out node statistics."),
 		cmds.BoolOption(enableStartupTest, "Allow BTFS to perform start up test.").WithDefault(true),
 
-
 		// TODO: add way to override addresses. tricky part: updating the config if also --init.
 		// cmds.StringOption(apiAddrKwd, "Address for the daemon rpc API (overrides config)"),
 		// cmds.StringOption(swarmAddrKwd, "Address for the swarm socket (overrides config)"),

--- a/cmd/btfs/daemon.go
+++ b/cmd/btfs/daemon.go
@@ -63,7 +63,7 @@ const (
 	enableMultiplexKwd        = "enable-mplex-experiment"
 	hValuekwd                 = "hval"
 	enableDataCollection      = "dc"
-	enableStartupTest		  = "enable-startup-test"
+	enableStartupTest         = "enable-startup-test"
 	// apiAddrKwd    = "address-api"
 	// swarmAddrKwd  = "address-swarm"
 )

--- a/cmd/btfs/daemon.go
+++ b/cmd/btfs/daemon.go
@@ -63,6 +63,7 @@ const (
 	enableMultiplexKwd        = "enable-mplex-experiment"
 	hValuekwd                 = "hval"
 	enableDataCollection      = "dc"
+	enableStartupTest		  = "enable-startup-test"
 	// apiAddrKwd    = "address-api"
 	// swarmAddrKwd  = "address-swarm"
 )
@@ -184,6 +185,8 @@ Headers.
 		cmds.BoolOption(enableMultiplexKwd, "Add the experimental 'go-multiplex' stream muxer to libp2p on construction.").WithDefault(true),
 		cmds.StringOption(hValuekwd, "The h value identifying the hosting bit torrent client"),
 		cmds.BoolOption(enableDataCollection, "Allow BTFS to collect and send out node statistics."),
+		cmds.BoolOption(enableStartupTest, "Allow BTFS to perform start up test.").WithDefault(true),
+
 
 		// TODO: add way to override addresses. tricky part: updating the config if also --init.
 		// cmds.StringOption(apiAddrKwd, "Address for the daemon rpc API (overrides config)"),
@@ -435,8 +438,13 @@ func daemonFunc(req *cmds.Request, re cmds.ResponseEmitter, env cmds.Environment
 
 	// The daemon is *finally* ready.
 	fmt.Printf("Daemon is ready\n")
+
+	runStartupTest, _ := req.Options[enableStartupTest].(bool)
+
 	// BTFS functional test
-	functest(cfg.StatusServerDomain, cfg.Identity.PeerID, hValue)
+	if runStartupTest {
+		functest(cfg.StatusServerDomain, cfg.Identity.PeerID, hValue)
+	}
 
 	//Begin sending analytics to hosted server
 	collectData, _ := req.Options[enableDataCollection].(bool)


### PR DESCRIPTION
added enable-startup-test as the flag to turn on/off start up test. default to true
usage : 
btfs daemon --enable-startup-test=0

tested end to end 