### PR TITLE
Update webui.go

### DIFF
--- a/core/corehttp/webui.go
+++ b/core/corehttp/webui.go
@@ -1,6 +1,6 @@
 package corehttp
 
-const WebUIPath = "/btfs/QmWHXwomLwoGo4DDAjTNyjno11k2Lzmd11RRFdukrJ51QX"
+const WebUIPath = "/btfs/QmTfM7Rz58Ejwq8Yg3jEEhtLc3BBxucpATiq4pRCy6TK4J"
 
 // this is a list of all past webUI paths.
 var WebUIPaths = []string{


### PR DESCRIPTION
This is to update the hash value of the latest build of the WebUI that has been uploaded to a BTFS bootstrap node. 

Creation of "build" hash:
![image](https://user-images.githubusercontent.com/32829113/67058313-1fade300-f109-11e9-9ba5-eec9eeeb2921.png)

Uploaded to bootstrap node:
![image](https://user-images.githubusercontent.com/32829113/67058301-09a02280-f109-11e9-8498-e2b9402963d1.png)
