### PR TITLE
BTFS-684: go-btfs changes. Also includes changes for BTFS-721

### DIFF
--- a/core/commands/block.go
+++ b/core/commands/block.go
@@ -103,7 +103,7 @@ It outputs to stdout, and <key> is a base58 encoded multihash.
 			return err
 		}
 
-		r, err := api.Block().Get(req.Context, path.New(req.Arguments[0]))
+		r, err := api.Block().Get(req.Context, path.New(req.Arguments[0]), false)
 		if err != nil {
 			return err
 		}

--- a/core/commands/cat.go
+++ b/core/commands/cat.go
@@ -15,9 +15,10 @@ import (
 )
 
 const (
-	progressBarMinSize = 1024 * 1024 * 8 // show progress bar for outputs > 8MiB
-	offsetOptionName   = "offset"
-	lengthOptionName   = "length"
+	progressBarMinSize       = 1024 * 1024 * 8 // show progress bar for outputs > 8MiB
+	offsetOptionName         = "offset"
+	lengthOptionName         = "length"
+	catMetaDisplayOptionName = "meta"
 )
 
 var CatCmd = &cmds.Command{
@@ -32,6 +33,7 @@ var CatCmd = &cmds.Command{
 	Options: []cmds.Option{
 		cmds.Int64Option(offsetOptionName, "o", "Byte offset to begin reading from."),
 		cmds.Int64Option(lengthOptionName, "l", "Maximum number of bytes to read."),
+		cmds.BoolOption(catMetaDisplayOptionName, "m", "Display token metadata"),
 	},
 	Run: func(req *cmds.Request, res cmds.ResponseEmitter, env cmds.Environment) error {
 		api, err := cmdenv.GetApi(env, req)
@@ -53,12 +55,14 @@ var CatCmd = &cmds.Command{
 			max = -1
 		}
 
+		meta, _ := req.Options[catMetaDisplayOptionName].(bool)
+
 		err = req.ParseBodyArgs()
 		if err != nil {
 			return err
 		}
 
-		readers, length, err := cat(req.Context, api, req.Arguments, int64(offset), int64(max))
+		readers, length, err := cat(req.Context, api, req.Arguments, int64(offset), int64(max), meta)
 		if err != nil {
 			return err
 		}
@@ -111,14 +115,14 @@ var CatCmd = &cmds.Command{
 	},
 }
 
-func cat(ctx context.Context, api iface.CoreAPI, paths []string, offset int64, max int64) ([]io.Reader, uint64, error) {
+func cat(ctx context.Context, api iface.CoreAPI, paths []string, offset int64, max int64, meta bool) ([]io.Reader, uint64, error) {
 	readers := make([]io.Reader, 0, len(paths))
 	length := uint64(0)
 	if max == 0 {
 		return nil, 0, nil
 	}
 	for _, p := range paths {
-		f, err := api.Unixfs().Get(ctx, path.New(p))
+		f, err := api.Unixfs().Get(ctx, path.New(p), meta)
 		if err != nil {
 			return nil, 0, err
 		}

--- a/core/commands/files.go
+++ b/core/commands/files.go
@@ -245,7 +245,7 @@ func statNode(nd ipld.Node, enc cidenc.Encoder) (*statOutput, error) {
 		switch d.Type() {
 		case ft.TDirectory, ft.THAMTShard:
 			ndtype = "directory"
-		case ft.TFile, ft.TMetadata, ft.TRaw:
+		case ft.TFile, ft.TMetadata, ft.TRaw, ft.TTokenMeta:
 			ndtype = "file"
 		default:
 			return nil, fmt.Errorf("unrecognized node type: %s", d.Type())

--- a/core/commands/get.go
+++ b/core/commands/get.go
@@ -28,6 +28,7 @@ const (
 	archiveOptionName          = "archive"
 	compressOptionName         = "compress"
 	compressionLevelOptionName = "compression-level"
+	getMetaDisplayOptionName   = "meta"
 )
 
 var GetCmd = &cmds.Command{
@@ -54,6 +55,7 @@ may also specify the level of compression by specifying '-l=<1-9>'.
 		cmds.BoolOption(archiveOptionName, "a", "Output a TAR archive."),
 		cmds.BoolOption(compressOptionName, "C", "Compress the output with GZIP compression."),
 		cmds.IntOption(compressionLevelOptionName, "l", "The level of compression (1-9)."),
+		cmds.BoolOption(getMetaDisplayOptionName, "m", "Display token metadata"),
 	},
 	PreRun: func(req *cmds.Request, env cmds.Environment) error {
 		_, err := getCompressOptions(req)
@@ -70,9 +72,11 @@ may also specify the level of compression by specifying '-l=<1-9>'.
 			return err
 		}
 
+		meta, _ := req.Options[getMetaDisplayOptionName].(bool)
+
 		p := path.New(req.Arguments[0])
 
-		file, err := api.Unixfs().Get(req.Context, p)
+		file, err := api.Unixfs().Get(req.Context, p, meta)
 		if err != nil {
 			return err
 		}

--- a/core/commands/object/object.go
+++ b/core/commands/object/object.go
@@ -251,7 +251,7 @@ Supported values are:
 			return err
 		}
 
-		nd, err := api.Object().Get(req.Context, path)
+		nd, err := api.Object().Get(req.Context, path, false)
 		if err != nil {
 			return err
 		}

--- a/core/commands/storage.go
+++ b/core/commands/storage.go
@@ -649,7 +649,7 @@ func downloadChunkFromClient(chunkInfo *storage.Chunk, chunkHash string, ssID st
 		return
 	}
 	p := path.New(chunkHash)
-	file, err := api.Unixfs().Get(context.Background(), p)
+	file, err := api.Unixfs().Get(context.Background(), p, false)
 	if err != nil {
 		log.Error(err)
 		sendSessionStatusChan(ss.SessionStatusChan, storage.UploadStatus, false, err)

--- a/core/coreapi/block.go
+++ b/core/coreapi/block.go
@@ -64,7 +64,7 @@ func (api *BlockAPI) Put(ctx context.Context, src io.Reader, opts ...caopts.Bloc
 	return &BlockStat{path: path.IpldPath(b.Cid()), size: len(data)}, nil
 }
 
-func (api *BlockAPI) Get(ctx context.Context, p path.Path) (io.Reader, error) {
+func (api *BlockAPI) Get(ctx context.Context, p path.Path, meta bool) (io.Reader, error) {
 	rp, err := api.core().ResolvePath(ctx, p)
 	if err != nil {
 		return nil, err

--- a/core/coreapi/object.go
+++ b/core/coreapi/object.go
@@ -15,6 +15,7 @@ import (
 	"github.com/TRON-US/go-btfs/pin"
 
 	ft "github.com/TRON-US/go-unixfs"
+	pb "github.com/TRON-US/go-unixfs/pb"
 	coreiface "github.com/TRON-US/interface-go-btfs-core"
 	caopts "github.com/TRON-US/interface-go-btfs-core/options"
 	ipath "github.com/TRON-US/interface-go-btfs-core/path"
@@ -128,7 +129,7 @@ func (api *ObjectAPI) Put(ctx context.Context, src io.Reader, opts ...caopts.Obj
 	return ipath.IpfsPath(dagnode.Cid()), nil
 }
 
-func (api *ObjectAPI) Get(ctx context.Context, path ipath.Path) (ipld.Node, error) {
+func (api *ObjectAPI) Get(ctx context.Context, path ipath.Path, meta bool) (ipld.Node, error) {
 	return api.core().ResolveNode(ctx, path)
 }
 
@@ -144,7 +145,9 @@ func (api *ObjectAPI) Data(ctx context.Context, path ipath.Path, unixfs bool, me
 	}
 
 	if unixfs {
-		pData, metaData, err := ft.StripOffTokenMetadata(pbnd.Data())
+		ds := api.core().Dag()
+
+		pData, metaData, err := getDataForUserAndMeta(pbnd, ds)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -157,6 +160,182 @@ func (api *ObjectAPI) Data(ctx context.Context, path ipath.Path, unixfs bool, me
 	} else {
 		return bytes.NewReader(pbnd.Data()), nil, nil
 	}
+}
+
+// Return user data, metadata in byte array, and error.
+// Note that this function assumes, if token metadata exists inside
+// the DAG topped by the given 'node', the 'node' has metadata root
+// as first child, user data root as second child.
+func getDataForUserAndMeta(nd ipld.Node, ds ipld.DAGService) ([]byte, []byte, error) {
+	n := nd.(*dag.ProtoNode)
+
+	fsType, err := getFSType(n)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if ft.TTokenMeta == fsType {
+		return nil, n.Data(), nil
+	}
+
+	// Return user data and metadata if first child is of type TTokenMeta.
+	if nd.Links() != nil && len(nd.Links()) >= 2 {
+		childen, err := getChildrenForDagWithMeta(nd, ds)
+		if err != nil {
+			return nil, nil, err
+		}
+		if childen == nil {
+			return nil, n.Data(), nil
+		}
+		return childen[1].(*dag.ProtoNode).Data(), childen[0].(*dag.ProtoNode).Data(), nil
+	}
+
+	return n.Data(), nil, nil
+}
+
+// Skips metadata if exists from the DAG topped by the given 'nd'.
+// Case #1: if 'nd' is dummy root with metadata root node and user data root node being children
+//    return the second child node that is the root of user data sub-DAG.
+// Case #2: if 'nd' is metadata, return none.
+// Case #3: if 'nd' is user data, return 'nd'.
+func skipMetadataIfExists(nd ipld.Node, ds ipld.DAGService) (ipld.Node, error) {
+	//var retNd ipld.Node = nil
+	n := nd.(*dag.ProtoNode)
+
+	fsType, err := getFSType(n)
+	if err != nil {
+		return nil, err
+	}
+
+	if ft.TTokenMeta == fsType {
+		return nil, fmt.Errorf("Token metadata can not be accessed by default")
+	}
+
+	// Return user data and metadata if first child is of type TTokenMeta.
+	if nd.Links() != nil && len(nd.Links()) >= 2 {
+		childen, err := getChildrenForDagWithMeta(nd, ds)
+		if err != nil {
+			return nil, err
+		}
+		if childen == nil {
+			return nd, nil
+		}
+		return childen[1], nil
+	}
+
+	return nd, nil
+}
+
+// Returns ipld.Node slice of size 2 if the given 'nd' is top of
+// the DAG with token metadata.
+func getChildrenForDagWithMeta(nd ipld.Node, ds ipld.DAGService) ([]ipld.Node, error) {
+	var nodes = make([]ipld.Node, 2)
+	for i := 0; i < 2; i++ {
+		lnk := nd.Links()[i]
+		c := lnk.Cid
+		child, err := ds.Get(context.Background(), c)
+		if err != nil {
+			return nil, err
+		}
+		childNode, ok := child.(*dag.ProtoNode)
+		if !ok {
+			return nil, err
+		}
+		if i == 0 {
+			// Make sure first child is of TTokenMeta.
+			// If not, return nil.
+			fsType, err := getFSType(childNode)
+			if err != nil {
+				return nil, err
+			}
+			if ft.TTokenMeta != fsType {
+				return nil, nil
+			}
+		}
+		nodes[i] = child
+	}
+
+	return nodes, nil
+}
+
+func getFSType(n *dag.ProtoNode) (pb.Data_DataType, error) {
+	d, err := ft.FSNodeFromBytes(n.Data())
+	if err != nil {
+		return 0, err
+	}
+
+	return d.Type(), nil
+}
+
+func (api *ObjectAPI) MetaDataMap(ctx context.Context, path ipath.Path) (map[string]interface{}, error) {
+	mr, err := api.MetaData(ctx, path)
+	if err != nil {
+		return nil, err
+	}
+
+	metaData, err := ioutil.ReadAll(mr)
+	if err != nil {
+		return nil, err
+	}
+
+	jmap := make(map[string]interface{})
+	err = json.Unmarshal(metaData, &jmap)
+	if err != nil {
+		return nil, err
+	}
+
+	return jmap, nil
+}
+
+func (api *ObjectAPI) MetaData(ctx context.Context, path ipath.Path) (io.Reader, error) {
+	nd, err := api.core().ResolveNode(ctx, path)
+	if err != nil {
+		return nil, err
+	}
+
+	_, ok := nd.(*dag.ProtoNode)
+	if !ok {
+		return nil, dag.ErrNotProtobuf
+	}
+
+	ds := api.core().Dag()
+
+	metaData, err := getMetaData(nd, ds)
+	if err != nil {
+		return nil, err
+	}
+
+	return bytes.NewReader(metaData), nil
+}
+
+// Return metadata under the given 'nd' node
+// if 'nd' has metadata root node aa its first child.
+func getMetaData(nd ipld.Node, ds ipld.DAGService) ([]byte, error) {
+	n := nd.(*dag.ProtoNode)
+
+	fsType, err := getFSType(n)
+	if err != nil {
+		return nil, err
+	}
+
+	if ft.TTokenMeta == fsType {
+		return n.Data(), nil
+	}
+
+	// Return metadata if first child is of type TTokenMeta.
+	var metadata []byte = nil
+	if nd.Links() != nil && len(nd.Links()) >= 2 {
+		children, err := getChildrenForDagWithMeta(nd, ds)
+		if err != nil {
+			return nil, err
+		}
+		if children == nil {
+			return nil, nil
+		}
+		return children[0].(*dag.ProtoNode).Data(), nil
+	}
+
+	return metadata, nil
 }
 
 func (api *ObjectAPI) Links(ctx context.Context, path ipath.Path) ([]*ipld.Link, error) {

--- a/core/coreapi/unixfs.go
+++ b/core/coreapi/unixfs.go
@@ -1,7 +1,6 @@
 package coreapi
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -11,20 +10,20 @@ import (
 	"github.com/TRON-US/go-btfs/core/coreunix"
 
 	files "github.com/TRON-US/go-btfs-files"
-	mfs "github.com/TRON-US/go-mfs"
+	"github.com/TRON-US/go-mfs"
 	ft "github.com/TRON-US/go-unixfs"
 	unixfile "github.com/TRON-US/go-unixfs/file"
 	uio "github.com/TRON-US/go-unixfs/io"
 	coreiface "github.com/TRON-US/interface-go-btfs-core"
-	options "github.com/TRON-US/interface-go-btfs-core/options"
-	path "github.com/TRON-US/interface-go-btfs-core/path"
-	blockservice "github.com/ipfs/go-blockservice"
-	cid "github.com/ipfs/go-cid"
-	cidutil "github.com/ipfs/go-cidutil"
+	"github.com/TRON-US/interface-go-btfs-core/options"
+	"github.com/TRON-US/interface-go-btfs-core/path"
+	"github.com/ipfs/go-blockservice"
+	"github.com/ipfs/go-cid"
+	"github.com/ipfs/go-cidutil"
 	bstore "github.com/ipfs/go-ipfs-blockstore"
 	ipld "github.com/ipfs/go-ipld-format"
+	"github.com/ipfs/go-merkledag"
 	dag "github.com/ipfs/go-merkledag"
-	merkledag "github.com/ipfs/go-merkledag"
 	dagtest "github.com/ipfs/go-merkledag/test"
 )
 
@@ -270,18 +269,28 @@ func (api *UnixfsAPI) AppendMetadata(metaMap map[string]interface{}, opts ...opt
 		return err
 	}
 
-	b, err := json.Marshal(metaMap)
-	if err != nil {
-		return err
-	}
-
-	buf := bytes.Buffer{}
+	var b []byte = nil
 	if settings.TokenMetadata != "" {
-		buf.WriteString(settings.TokenMetadata)
+		tmp := make(map[string]interface{})
+		err = json.Unmarshal([]byte(settings.TokenMetadata), &tmp)
+		if err != nil {
+			return err
+		}
+		for k, v := range metaMap {
+			tmp[k] = v
+		}
+		b, err = json.Marshal(tmp)
+		if err != nil {
+			return err
+		}
+	} else {
+		b, err = json.Marshal(metaMap)
+		if err != nil {
+			return err
+		}
 	}
-	buf.WriteString(string(b))
 
-	settings.TokenMetadata = buf.String()
+	settings.TokenMetadata = string(b)
 
 	return nil
 }

--- a/core/coreapi/unixfs.go
+++ b/core/coreapi/unixfs.go
@@ -150,26 +150,7 @@ func (api *UnixfsAPI) Get(ctx context.Context, p path.Path, metadata bool) (file
 		return nil, err
 	}
 
-	// Skip token metadata if the given 'metadata' is false. I.e.,
-	// check if the given 'p' represents a dummy root of a DAG with token metadata.
-	// If yes, get the root node of the user data that is the second child
-	// of the the dummy root. Then set this child node to 'nd'.
-	// Note that a new UnixFS type to indicate existence of metadata will be faster but
-	// a new type causes many changes.
-	if !metadata {
-		if _, ok := nd.(*dag.ProtoNode); ok {
-			newNode, err := skipMetadataIfExists(nd, api.core().Dag())
-			if err != nil {
-				return nil, err
-			}
-			if newNode == nil {
-				return nil, nil
-			}
-			nd = newNode
-		}
-	}
-
-	return unixfile.NewUnixfsFile(ctx, ses.dag, nd)
+	return unixfile.NewUnixfsFile(ctx, ses.dag, nd, metadata)
 }
 
 // Ls returns the contents of an BTFS or BTNS object(s) at path p, with the format:

--- a/core/corehttp/gateway_handler.go
+++ b/core/corehttp/gateway_handler.go
@@ -172,7 +172,7 @@ func (i *gatewayHandler) getOrHeadHandler(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	dr, err := i.api.Unixfs().Get(r.Context(), resolvedPath)
+	dr, err := i.api.Unixfs().Get(r.Context(), resolvedPath, false)
 	if err != nil {
 		webError(w, "btfs cat "+escapedURLPath, err, http.StatusNotFound)
 		return
@@ -257,7 +257,7 @@ func (i *gatewayHandler) getOrHeadHandler(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	idx, err := i.api.Unixfs().Get(r.Context(), ipath.Join(resolvedPath, "index.html"))
+	idx, err := i.api.Unixfs().Get(r.Context(), ipath.Join(resolvedPath, "index.html"), false)
 	switch err.(type) {
 	case nil:
 		dirwithoutslash := urlPath[len(urlPath)-1] != '/'

--- a/core/corehttp/gateway_test.go
+++ b/core/corehttp/gateway_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 // `btfs object new unixfs-dir`
-var emptyDir = "/btfs/QmdUmxr5nZmSiHxbPR5LKzEPPBxJR878Eoh7JSqmJLPjbx"
+var emptyDir = "/btfs/QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn"
 
 type mockNamesys map[string]path.Path
 

--- a/fuse/readonly/ipfs_test.go
+++ b/fuse/readonly/ipfs_test.go
@@ -198,7 +198,7 @@ func TestIpfsStressRead(t *testing.T) {
 				//hitting 8128 goroutine limit in go test -race mode
 				ctx, cancelFunc := context.WithCancel(context.Background())
 
-				read, err := api.Unixfs().Get(ctx, item)
+				read, err := api.Unixfs().Get(ctx, item, false)
 				if err != nil {
 					errs <- err
 				}

--- a/go.mod
+++ b/go.mod
@@ -6,13 +6,13 @@ require (
 	github.com/FactomProject/btcutilecc v0.0.0-20130527213604-d3a63a5752ec // indirect
 	github.com/Kubuxu/gocovmerge v0.0.0-20161216165753-7ecaa51963cd
 	github.com/StackExchange/wmi v0.0.0-20181212234831-e0a55b97c705 // indirect
-	github.com/TRON-US/go-btfs-chunker v0.2.1
+	github.com/TRON-US/go-btfs-chunker v0.2.2
 	github.com/TRON-US/go-btfs-cmds v0.1.5
 	github.com/TRON-US/go-btfs-config v0.1.7
 	github.com/TRON-US/go-btfs-files v0.1.1
 	github.com/TRON-US/go-mfs v0.2.1
-	github.com/TRON-US/go-unixfs v0.4.2
-	github.com/TRON-US/interface-go-btfs-core v0.3.9
+	github.com/TRON-US/go-unixfs v0.4.4
+	github.com/TRON-US/interface-go-btfs-core v0.4.0
 	github.com/Workiva/go-datastructures v1.0.50
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/bren2010/proquint v0.0.0-20160323162903-38337c27106d

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/TRON-US/go-btfs-config v0.1.7
 	github.com/TRON-US/go-btfs-files v0.1.1
 	github.com/TRON-US/go-mfs v0.2.1
-	github.com/TRON-US/go-unixfs v0.4.4
+	github.com/TRON-US/go-unixfs v0.4.5
 	github.com/TRON-US/interface-go-btfs-core v0.4.0
 	github.com/Workiva/go-datastructures v1.0.50
 	github.com/blang/semver v3.5.1+incompatible

--- a/go.sum
+++ b/go.sum
@@ -26,6 +26,8 @@ github.com/TRON-US/go-btfs-chunker v0.2.0 h1:dp80UzRmUFzDDDt4nqo2STGVh5I4jDQJRYJ
 github.com/TRON-US/go-btfs-chunker v0.2.0/go.mod h1:6wFL7KgEumsn7R7IGFZZhOGIHxA/YkA4RdfR553M3Fk=
 github.com/TRON-US/go-btfs-chunker v0.2.1 h1:CD4lMIjfJMjMm8UitIc2NN5tR8LrPpQ8lEVtOiXwDYg=
 github.com/TRON-US/go-btfs-chunker v0.2.1/go.mod h1:Wj0oyybAWtu5lpcAc90QQ3bhJ14JRXD50PqxP25wmnI=
+github.com/TRON-US/go-btfs-chunker v0.2.2 h1:aiLDsiM3X2Yy2jVo3EQYYEVkw57SThOUPTs0Ja5yPeA=
+github.com/TRON-US/go-btfs-chunker v0.2.2/go.mod h1:Wj0oyybAWtu5lpcAc90QQ3bhJ14JRXD50PqxP25wmnI=
 github.com/TRON-US/go-btfs-cmds v0.1.5 h1:AbnAPBAFxe67MPChbwFPJbyKY1Vm3lXybGDNQ4NUTno=
 github.com/TRON-US/go-btfs-cmds v0.1.5/go.mod h1:rtki4vmPzq7qmjdzThJELFpSpxTiORoXreHlExdI6eg=
 github.com/TRON-US/go-btfs-config v0.1.7 h1:d5znAqVAslgnHNZZG6vs2fTZuzuq4WWJmO9PhYXBX5g=
@@ -40,8 +42,14 @@ github.com/TRON-US/go-unixfs v0.4.1 h1:Vo1qIr8HT5D2GlfXaLG1lMrHq4plUyl1udIkCdVuF
 github.com/TRON-US/go-unixfs v0.4.1/go.mod h1:h/I7boDSgPi4Kw6qD/VJKQA62/+Lt+Zvb4nMRO57R1c=
 github.com/TRON-US/go-unixfs v0.4.2 h1:kbG1edpyFp4FqRh2nUuK06LAMzLO8ziOyYW46jL0lOs=
 github.com/TRON-US/go-unixfs v0.4.2/go.mod h1:yY17inMS7iFmmLqz4bCCj6l9b3Mk9UHaVDFCoCF/+jk=
+github.com/TRON-US/go-unixfs v0.4.3-dev h1:RpPOIFdBMt/u+1Equ+NGbogsvcOF3ppcPfgRgGmhYtc=
+github.com/TRON-US/go-unixfs v0.4.3-dev/go.mod h1:KJOb8DrNKJH9cdufqZba8ljdt3/vyo0KwfWNtwTzZbQ=
+github.com/TRON-US/go-unixfs v0.4.4 h1:EzTr7aHrB/vlAr4onYb/ENdsFt0NYNUGAefVD93r28w=
+github.com/TRON-US/go-unixfs v0.4.4/go.mod h1:VBRlISp23R6JoJQ2t+O/VkIswnPo9PBVCh5blMpN0GI=
 github.com/TRON-US/interface-go-btfs-core v0.3.9 h1:zLgjQ/jT53K35G39uAnRwbXU7F0cQxaquIJ8Rf1u40s=
 github.com/TRON-US/interface-go-btfs-core v0.3.9/go.mod h1:MayxoV6/Pav5aPq+8RAsMfcc9cH7yeypAN82RAF0aZY=
+github.com/TRON-US/interface-go-btfs-core v0.4.0 h1:O06NPfXqpNiq1mhEu6QE1b/vEt/tKE0GEb3GEGYnpfM=
+github.com/TRON-US/interface-go-btfs-core v0.4.0/go.mod h1:wZWJikVV3ShW7fClZP8/Gv8gYFg4ZowePkKBp0HY9Xc=
 github.com/Workiva/go-datastructures v1.0.50 h1:slDmfW6KCHcC7U+LP3DDBbm4fqTwZGn1beOFPfGaLvo=
 github.com/Workiva/go-datastructures v1.0.50/go.mod h1:Z+F2Rca0qCsVYDS8z7bAGm8f3UkzuWYS/oBZz5a7VVA=
 github.com/aead/siphash v1.0.1/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBAUSII=
@@ -305,6 +313,7 @@ github.com/ipfs/go-ipfs-exchange-interface v0.0.1 h1:LJXIo9W7CAmugqI+uofioIpRb6r
 github.com/ipfs/go-ipfs-exchange-interface v0.0.1/go.mod h1:c8MwfHjtQjPoDyiy9cFquVtVHkO9b9Ob3FG91qJnWCM=
 github.com/ipfs/go-ipfs-exchange-offline v0.0.1 h1:P56jYKZF7lDDOLx5SotVh5KFxoY6C81I1NSHW1FxGew=
 github.com/ipfs/go-ipfs-exchange-offline v0.0.1/go.mod h1:WhHSFCVYX36H/anEKQboAzpUws3x7UeEGkzQc3iNkM0=
+github.com/ipfs/go-ipfs-files v0.0.1 h1:OroTsI58plHGX70HPLKy6LQhPR3HZJ5ip61fYlo6POM=
 github.com/ipfs/go-ipfs-files v0.0.1/go.mod h1:INEFm0LL2LWXBhNJ2PMIIb2w45hpXgPjNoE7yA8Y1d4=
 github.com/ipfs/go-ipfs-files v0.0.3 h1:ME+QnC3uOyla1ciRPezDW0ynQYK2ikOh9OCKAEg4uUA=
 github.com/ipfs/go-ipfs-files v0.0.3/go.mod h1:INEFm0LL2LWXBhNJ2PMIIb2w45hpXgPjNoE7yA8Y1d4=

--- a/go.sum
+++ b/go.sum
@@ -46,6 +46,8 @@ github.com/TRON-US/go-unixfs v0.4.3-dev h1:RpPOIFdBMt/u+1Equ+NGbogsvcOF3ppcPfgRg
 github.com/TRON-US/go-unixfs v0.4.3-dev/go.mod h1:KJOb8DrNKJH9cdufqZba8ljdt3/vyo0KwfWNtwTzZbQ=
 github.com/TRON-US/go-unixfs v0.4.4 h1:EzTr7aHrB/vlAr4onYb/ENdsFt0NYNUGAefVD93r28w=
 github.com/TRON-US/go-unixfs v0.4.4/go.mod h1:VBRlISp23R6JoJQ2t+O/VkIswnPo9PBVCh5blMpN0GI=
+github.com/TRON-US/go-unixfs v0.4.5 h1:VUda4IfFy5iG+DRvNX2T7sH8HD0NmlroLy4/bMaedQU=
+github.com/TRON-US/go-unixfs v0.4.5/go.mod h1:VBRlISp23R6JoJQ2t+O/VkIswnPo9PBVCh5blMpN0GI=
 github.com/TRON-US/interface-go-btfs-core v0.3.9 h1:zLgjQ/jT53K35G39uAnRwbXU7F0cQxaquIJ8Rf1u40s=
 github.com/TRON-US/interface-go-btfs-core v0.3.9/go.mod h1:MayxoV6/Pav5aPq+8RAsMfcc9cH7yeypAN82RAF0aZY=
 github.com/TRON-US/interface-go-btfs-core v0.4.0 h1:O06NPfXqpNiq1mhEu6QE1b/vEt/tKE0GEb3GEGYnpfM=

--- a/test/integration/addcat_test.go
+++ b/test/integration/addcat_test.go
@@ -153,7 +153,7 @@ func DirectAddCat(data []byte, conf testutil.LatencyConfig) error {
 		return err
 	}
 
-	readerCatted, err := catterApi.Unixfs().Get(ctx, added)
+	readerCatted, err := catterApi.Unixfs().Get(ctx, added, false)
 	if err != nil {
 		return err
 	}

--- a/test/integration/bench_cat_test.go
+++ b/test/integration/bench_cat_test.go
@@ -97,7 +97,7 @@ func benchCat(b *testing.B, data []byte, conf testutil.LatencyConfig) error {
 	}
 
 	b.StartTimer()
-	readerCatted, err := catterApi.Unixfs().Get(ctx, added)
+	readerCatted, err := catterApi.Unixfs().Get(ctx, added, false)
 	if err != nil {
 		return err
 	}

--- a/test/integration/three_legged_cat_test.go
+++ b/test/integration/three_legged_cat_test.go
@@ -132,7 +132,7 @@ func RunThreeLeggedCat(data []byte, conf testutil.LatencyConfig) error {
 		return err
 	}
 
-	readerCatted, err := catterApi.Unixfs().Get(ctx, added)
+	readerCatted, err := catterApi.Unixfs().Get(ctx, added, false)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
1. core/commands/* has command driver changes for "btfs get" and "btfs cat" and minor changes in other files.
2. core/coreapi/object.go has changes for new metadata structure and 
   token metadata retrieval functions. 
3. core/coreapi/unixfs.go has changes for drivers for DAG building (which is verified from
go-unixfs/balanced/balanced_test.go and go-unixfs/io/read_solomon_dagreader_test.go with 
go-unixfs/test/utils.go:GetNode()) and a method to attach metadata. 