### PR TITLE
BTFS-648: Add metadata into reed solomon chunker

### DIFF
--- a/core/coreunix/metadata.go
+++ b/core/coreunix/metadata.go
@@ -1,9 +1,16 @@
 package coreunix
 
 import (
+	"context"
+	"encoding/json"
+
 	core "github.com/TRON-US/go-btfs/core"
+
 	ft "github.com/TRON-US/go-unixfs"
+	coreiface "github.com/TRON-US/interface-go-btfs-core"
+	ipath "github.com/TRON-US/interface-go-btfs-core/path"
 	cid "github.com/ipfs/go-cid"
+	ipld "github.com/ipfs/go-ipld-format"
 	dag "github.com/ipfs/go-merkledag"
 )
 
@@ -54,4 +61,78 @@ func Metadata(n *core.IpfsNode, skey string) (*ft.Metadata, error) {
 	}
 
 	return ft.MetadataFromBytes(pbnd.Data())
+}
+
+func MetaDataMap(ctx context.Context, api coreiface.CoreAPI, path ipath.Path) (map[string]interface{}, error) {
+	metaData, err := MetaData(ctx, api, path)
+	if err != nil {
+		return nil, err
+	}
+
+	jmap := make(map[string]interface{})
+	err = json.Unmarshal(metaData, &jmap)
+	if err != nil {
+		return nil, err
+	}
+
+	return jmap, nil
+}
+
+func MetaData(ctx context.Context, api coreiface.CoreAPI, path ipath.Path) ([]byte, error) {
+	nd, err := api.ResolveNode(ctx, path)
+	if err != nil {
+		return nil, err
+	}
+
+	_, ok := nd.(*dag.ProtoNode)
+	if !ok {
+		return nil, dag.ErrNotProtobuf
+	}
+
+	ds := api.Dag()
+
+	metaData, err := getMetaData(ctx, nd, ds)
+	if err != nil {
+		return nil, err
+	}
+
+	return metaData, nil
+}
+
+// GetMetaData returns metadata under the given 'nd' node
+// if 'nd' has metadata root node aa its first child.
+func getMetaData(ctx context.Context, nd ipld.Node, ds ipld.DAGService) ([]byte, error) {
+	_, metadata, err := GetDataForUserAndMeta(ctx, nd, ds)
+	return metadata, err
+}
+
+// GetDataForUserAndMeta returns user data, metadata in byte array, and error.
+// Note that this function assumes, if token metadata exists inside
+// the DAG topped by the given 'node', the 'node' has metadata root
+// as first child, user data root as second child.
+func GetDataForUserAndMeta(ctx context.Context, nd ipld.Node, ds ipld.DAGService) ([]byte, []byte, error) {
+	n := nd.(*dag.ProtoNode)
+
+	fsType, err := ft.GetFSType(n)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if ft.TTokenMeta == fsType {
+		return nil, n.Data(), nil
+	}
+
+	// Return user data and metadata if first child is of type TTokenMeta.
+	if nd.Links() != nil && len(nd.Links()) >= 2 {
+		childen, err := ft.GetChildrenForDagWithMeta(ctx, nd, ds)
+		if err != nil {
+			return nil, nil, err
+		}
+		if childen == nil {
+			return nil, n.Data(), nil
+		}
+		return childen[1].(*dag.ProtoNode).Data(), childen[0].(*dag.ProtoNode).Data(), nil
+	}
+
+	return n.Data(), nil, nil
 }

--- a/core/coreunix/test/add_test.go
+++ b/core/coreunix/test/add_test.go
@@ -1,8 +1,10 @@
-package coreunix
+package test
 
 import (
 	"bytes"
 	"context"
+	"encoding/json"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"math/rand"
@@ -12,12 +14,16 @@ import (
 	"time"
 
 	"github.com/TRON-US/go-btfs/core"
+	"github.com/TRON-US/go-btfs/core/coreapi"
+	"github.com/TRON-US/go-btfs/core/coreunix"
 	"github.com/TRON-US/go-btfs/pin/gc"
 	"github.com/TRON-US/go-btfs/repo"
 
+	chunker "github.com/TRON-US/go-btfs-chunker"
 	config "github.com/TRON-US/go-btfs-config"
 	files "github.com/TRON-US/go-btfs-files"
 	coreiface "github.com/TRON-US/interface-go-btfs-core"
+	"github.com/TRON-US/interface-go-btfs-core/path"
 	blocks "github.com/ipfs/go-block-format"
 	"github.com/ipfs/go-blockservice"
 	cid "github.com/ipfs/go-cid"
@@ -45,7 +51,7 @@ func TestAddMultipleGCLive(t *testing.T) {
 	}
 
 	out := make(chan interface{}, 10)
-	adder, err := NewAdder(context.Background(), node.Pinning, node.Blockstore, node.DAG)
+	adder, err := coreunix.NewAdder(context.Background(), node.Pinning, node.Blockstore, node.DAG)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -155,7 +161,7 @@ func TestAddGCLive(t *testing.T) {
 	}
 
 	out := make(chan interface{})
-	adder, err := NewAdder(context.Background(), node.Pinning, node.Blockstore, node.DAG)
+	adder, err := coreunix.NewAdder(context.Background(), node.Pinning, node.Blockstore, node.DAG)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -253,6 +259,79 @@ func TestAddGCLive(t *testing.T) {
 	}
 }
 
+func TestAddWithReedSolomonMetadata(t *testing.T) {
+	r := &repo.Mock{
+		C: config.Config{
+			Identity: config.Identity{
+				PeerID: testPeerID, // required by offline node
+			},
+		},
+		D: syncds.MutexWrap(datastore.NewMapDatastore()),
+	}
+	node, err := core.NewNode(context.Background(), &core.BuildCfg{Repo: r})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	out := make(chan interface{})
+	adder, err := coreunix.NewAdder(context.Background(), node.Pinning, node.Blockstore, node.DAG)
+	if err != nil {
+		t.Fatal(err)
+	}
+	adder.Out = out
+	// Set to default reed solomon for metadata
+	dsize, psize, csize := 10, 20, 262144
+	adder.Chunker = fmt.Sprintf("reed-solomon-%d-%d-%d", dsize, psize, csize)
+
+	fb := []byte("testfileA")
+	fsize := len(fb)
+	rfa := files.NewBytesFile(fb)
+
+	go func() {
+		defer close(out)
+		_, err := adder.AddAllAndPin(rfa)
+
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
+
+	var addedHash cid.Cid
+	select {
+	case o := <-out:
+		addedHash = o.(*coreiface.AddEvent).Path.Cid()
+	case <-ctx.Done():
+		t.Fatal("add timed out")
+	}
+
+	api, err := coreapi.NewCoreAPI(node)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Extract and check metadata
+	b, err := coreunix.MetaData(ctx, api, path.IpfsPath(addedHash))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var rsMeta chunker.RsMetaMap
+	err = json.Unmarshal(b, &rsMeta)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rsMeta.NumData != uint64(dsize) {
+		t.Fatal("reed solomon metadata num data does not match")
+	}
+	if rsMeta.NumParity != uint64(psize) {
+		t.Fatal("reed solomon metadata num parity does not match")
+	}
+	if rsMeta.FileSize != uint64(fsize) {
+		t.Fatal("reed solomon metadata file size does not match")
+	}
+}
+
 func testAddWPosInfo(t *testing.T, rawLeaves bool) {
 	r := &repo.Mock{
 		C: config.Config{
@@ -270,7 +349,7 @@ func testAddWPosInfo(t *testing.T, rawLeaves bool) {
 	bs := &testBlockstore{GCBlockstore: node.Blockstore, expectedPath: filepath.Join(os.TempDir(), "foo.txt"), t: t}
 	bserv := blockservice.New(bs, node.Exchange)
 	dserv := dag.NewDAGService(bserv)
-	adder, err := NewAdder(context.Background(), node.Pinning, bs, dserv)
+	adder, err := coreunix.NewAdder(context.Background(), node.Pinning, bs, dserv)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/core/coreunix/test/metadata_test.go
+++ b/core/coreunix/test/metadata_test.go
@@ -1,4 +1,4 @@
-package coreunix
+package test
 
 import (
 	"bytes"
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	core "github.com/TRON-US/go-btfs/core"
+	coreunix "github.com/TRON-US/go-btfs/core/coreunix"
 	ft "github.com/TRON-US/go-unixfs"
 	importer "github.com/TRON-US/go-unixfs/importer"
 	uio "github.com/TRON-US/go-unixfs/io"
@@ -54,12 +55,12 @@ func TestMetadata(t *testing.T) {
 	// Such effort, many compromise
 	ipfsnode := &core.IpfsNode{DAG: ds}
 
-	mdk, err := AddMetadataTo(ipfsnode, c.String(), m)
+	mdk, err := coreunix.AddMetadataTo(ipfsnode, c.String(), m)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	rec, err := Metadata(ipfsnode, mdk)
+	rec, err := coreunix.Metadata(ipfsnode, mdk)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -67,7 +67,6 @@ require (
 	github.com/ipfs/hang-fds v0.0.1
 	github.com/ipfs/iptb v1.4.0
 	github.com/ipfs/iptb-plugins v0.1.0
-	github.com/jbenet/go-fuse-version v0.0.0-20160322195114-6d4c97bcf253 // indirect
 	github.com/jbenet/go-is-domain v1.0.2
 	github.com/jbenet/go-random v0.0.0-20190219211222-123a90aedc0c
 	github.com/jbenet/go-random-files v0.0.0-20190219210431-31b3f20ebded

--- a/go.mod
+++ b/go.mod
@@ -145,3 +145,5 @@ require (
 go 1.12
 
 replace github.com/golangci/golangci-lint => github.com/mhutchinson/golangci-lint v1.17.2-0.20190909151044-da0150b86be6
+
+replace github.com/TRON-US/go-btfs-chunker => ../go-btfs-chunker

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/TRON-US/go-btfs-config v0.1.8
 	github.com/TRON-US/go-btfs-files v0.1.1
 	github.com/TRON-US/go-mfs v0.2.1
-	github.com/TRON-US/go-unixfs v0.4.5
+	github.com/TRON-US/go-unixfs v0.4.6
 	github.com/TRON-US/interface-go-btfs-core v0.4.0
 	github.com/Workiva/go-datastructures v1.0.50
 	github.com/blang/semver v3.5.1+incompatible
@@ -67,6 +67,7 @@ require (
 	github.com/ipfs/hang-fds v0.0.1
 	github.com/ipfs/iptb v1.4.0
 	github.com/ipfs/iptb-plugins v0.1.0
+	github.com/jbenet/go-fuse-version v0.0.0-20160322195114-6d4c97bcf253 // indirect
 	github.com/jbenet/go-is-domain v1.0.2
 	github.com/jbenet/go-random v0.0.0-20190219211222-123a90aedc0c
 	github.com/jbenet/go-random-files v0.0.0-20190219210431-31b3f20ebded

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/FactomProject/btcutilecc v0.0.0-20130527213604-d3a63a5752ec // indirect
 	github.com/Kubuxu/gocovmerge v0.0.0-20161216165753-7ecaa51963cd
 	github.com/StackExchange/wmi v0.0.0-20181212234831-e0a55b97c705 // indirect
-	github.com/TRON-US/go-btfs-chunker v0.2.2
+	github.com/TRON-US/go-btfs-chunker v0.2.3
 	github.com/TRON-US/go-btfs-cmds v0.1.5
 	github.com/TRON-US/go-btfs-config v0.1.8
 	github.com/TRON-US/go-btfs-files v0.1.1
@@ -145,5 +145,3 @@ require (
 go 1.12
 
 replace github.com/golangci/golangci-lint => github.com/mhutchinson/golangci-lint v1.17.2-0.20190909151044-da0150b86be6
-
-replace github.com/TRON-US/go-btfs-chunker => ../go-btfs-chunker

--- a/go.sum
+++ b/go.sum
@@ -370,8 +370,6 @@ github.com/jackpal/go-nat-pmp v1.0.1/go.mod h1:QPH045xvCAeXUZOxsnwmrtiCoxIr9eob+
 github.com/jbenet/go-cienv v0.0.0-20150120210510-1bb1476777ec/go.mod h1:rGaEvXB4uRSZMmzKNLoXvTu1sfx+1kv/DojUlPrSZGs=
 github.com/jbenet/go-cienv v0.1.0 h1:Vc/s0QbQtoxX8MwwSLWWh+xNNZvM3Lw7NsTcHrvvhMc=
 github.com/jbenet/go-cienv v0.1.0/go.mod h1:TqNnHUmJgXau0nCzC7kXWeotg3J9W34CUv5Djy1+FlA=
-github.com/jbenet/go-fuse-version v0.0.0-20160322195114-6d4c97bcf253 h1:+AUuGGAh/2X3wcomiZvjeTcx5OvGXsfdnIqk3KPM+HE=
-github.com/jbenet/go-fuse-version v0.0.0-20160322195114-6d4c97bcf253/go.mod h1:gWtF+3u3zVe5/+I44niTEcU/KmVo2oMyLh0WhxpBT28=
 github.com/jbenet/go-is-domain v1.0.2 h1:11r5MSptcNFZyBoqubBQnVMUKRWLuRjL1banaIk+iYo=
 github.com/jbenet/go-is-domain v1.0.2/go.mod h1:xbRLRb0S7FgzDBTJlguhDVwLYM/5yNtvktxj2Ttfy7Q=
 github.com/jbenet/go-random v0.0.0-20190219211222-123a90aedc0c h1:uUx61FiAa1GI6ZmVd2wf2vULeQZIKG66eybjNXKYCz4=

--- a/go.sum
+++ b/go.sum
@@ -40,8 +40,8 @@ github.com/TRON-US/go-unixfs v0.3.0 h1:mbmSHVGZbkV5NVRuQHZ/Cw8BMta74GVeOY3TE76Tv
 github.com/TRON-US/go-unixfs v0.3.0/go.mod h1:t0JHRUZ0MbDhD1S5jNXByrkX1mfbftJ+0jE89+Bv044=
 github.com/TRON-US/go-unixfs v0.4.4 h1:EzTr7aHrB/vlAr4onYb/ENdsFt0NYNUGAefVD93r28w=
 github.com/TRON-US/go-unixfs v0.4.4/go.mod h1:VBRlISp23R6JoJQ2t+O/VkIswnPo9PBVCh5blMpN0GI=
-github.com/TRON-US/go-unixfs v0.4.5 h1:VUda4IfFy5iG+DRvNX2T7sH8HD0NmlroLy4/bMaedQU=
-github.com/TRON-US/go-unixfs v0.4.5/go.mod h1:VBRlISp23R6JoJQ2t+O/VkIswnPo9PBVCh5blMpN0GI=
+github.com/TRON-US/go-unixfs v0.4.6 h1:XpWXOdolCTZ4UOkLj3a73pJvHKAGqdR7cAH2x4+daow=
+github.com/TRON-US/go-unixfs v0.4.6/go.mod h1:+Llf5BXSKEaK4HHf1+/eehGwWsEUilNymR1N7a69Y9k=
 github.com/TRON-US/interface-go-btfs-core v0.4.0 h1:O06NPfXqpNiq1mhEu6QE1b/vEt/tKE0GEb3GEGYnpfM=
 github.com/TRON-US/interface-go-btfs-core v0.4.0/go.mod h1:wZWJikVV3ShW7fClZP8/Gv8gYFg4ZowePkKBp0HY9Xc=
 github.com/Workiva/go-datastructures v1.0.50 h1:slDmfW6KCHcC7U+LP3DDBbm4fqTwZGn1beOFPfGaLvo=
@@ -370,6 +370,8 @@ github.com/jackpal/go-nat-pmp v1.0.1/go.mod h1:QPH045xvCAeXUZOxsnwmrtiCoxIr9eob+
 github.com/jbenet/go-cienv v0.0.0-20150120210510-1bb1476777ec/go.mod h1:rGaEvXB4uRSZMmzKNLoXvTu1sfx+1kv/DojUlPrSZGs=
 github.com/jbenet/go-cienv v0.1.0 h1:Vc/s0QbQtoxX8MwwSLWWh+xNNZvM3Lw7NsTcHrvvhMc=
 github.com/jbenet/go-cienv v0.1.0/go.mod h1:TqNnHUmJgXau0nCzC7kXWeotg3J9W34CUv5Djy1+FlA=
+github.com/jbenet/go-fuse-version v0.0.0-20160322195114-6d4c97bcf253 h1:+AUuGGAh/2X3wcomiZvjeTcx5OvGXsfdnIqk3KPM+HE=
+github.com/jbenet/go-fuse-version v0.0.0-20160322195114-6d4c97bcf253/go.mod h1:gWtF+3u3zVe5/+I44niTEcU/KmVo2oMyLh0WhxpBT28=
 github.com/jbenet/go-is-domain v1.0.2 h1:11r5MSptcNFZyBoqubBQnVMUKRWLuRjL1banaIk+iYo=
 github.com/jbenet/go-is-domain v1.0.2/go.mod h1:xbRLRb0S7FgzDBTJlguhDVwLYM/5yNtvktxj2Ttfy7Q=
 github.com/jbenet/go-random v0.0.0-20190219211222-123a90aedc0c h1:uUx61FiAa1GI6ZmVd2wf2vULeQZIKG66eybjNXKYCz4=

--- a/go.sum
+++ b/go.sum
@@ -26,6 +26,8 @@ github.com/TRON-US/go-btfs-chunker v0.2.0 h1:dp80UzRmUFzDDDt4nqo2STGVh5I4jDQJRYJ
 github.com/TRON-US/go-btfs-chunker v0.2.0/go.mod h1:6wFL7KgEumsn7R7IGFZZhOGIHxA/YkA4RdfR553M3Fk=
 github.com/TRON-US/go-btfs-chunker v0.2.2 h1:aiLDsiM3X2Yy2jVo3EQYYEVkw57SThOUPTs0Ja5yPeA=
 github.com/TRON-US/go-btfs-chunker v0.2.2/go.mod h1:Wj0oyybAWtu5lpcAc90QQ3bhJ14JRXD50PqxP25wmnI=
+github.com/TRON-US/go-btfs-chunker v0.2.3 h1:ky/HsQY8UU+Mas3qXptwO9x3Pd2HWDDm+ycpS+NI9Js=
+github.com/TRON-US/go-btfs-chunker v0.2.3/go.mod h1:Wj0oyybAWtu5lpcAc90QQ3bhJ14JRXD50PqxP25wmnI=
 github.com/TRON-US/go-btfs-cmds v0.1.5 h1:AbnAPBAFxe67MPChbwFPJbyKY1Vm3lXybGDNQ4NUTno=
 github.com/TRON-US/go-btfs-cmds v0.1.5/go.mod h1:rtki4vmPzq7qmjdzThJELFpSpxTiORoXreHlExdI6eg=
 github.com/TRON-US/go-btfs-config v0.1.8 h1:FrYhoesR/+dP4VR+VYgmu3QNenGT5v+mQph9VR+JevA=


### PR DESCRIPTION
- During adding of a reed solomon chunked file, read the metadata bytes from the chunker and insert directly into the tokenmetadata field
- Moved metadata helpers from coreapi/ into coreunix/ for coreunix functions to use them - also fixed the issue of unmarshalling raw dag node - now it unmarshals the fs node data correctly
- Moved coreunix tests into coreunix/test to avoid circular dependencies