### PR TITLE
BTFS-952: Metadata commands update

### DIFF
--- a/core/coreapi/unixfs.go
+++ b/core/coreapi/unixfs.go
@@ -149,6 +149,13 @@ func (api *UnixfsAPI) Get(ctx context.Context, p path.Path, metadata bool) (file
 		return nil, err
 	}
 
+	if metadata {
+		mnd, err := ft.GetMetaSubdagRoot(ctx, nd, ses.dag)
+		if err != nil {
+			return nil, err
+		}
+		return unixfile.NewUnixfsFile(ctx, ses.dag, mnd, metadata)
+	}
 	return unixfile.NewUnixfsFile(ctx, ses.dag, nd, metadata)
 }
 


### PR DESCRIPTION
1. Modified core/coreapi/unixfs.go:Get(..) to return only metadata when the given `metadata bool` is true. 
2. `btfs get $cid -m` and `btfs cat $cid -m` works to return only metadata. 