### PR TITLE
BTFS-937 add docker compose for building binary files 

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3'
+services:
+  btfs-build-binaries:
+    build:
+      context: .
+      dockerfile: Dockerfile.unit_testing
+    volumes:
+      - ../btfs-binary-releases:/btfs-binary-releases
+    command:
+      bash -c "chmod 777 package.sh && ./package.sh"


### PR DESCRIPTION
in order to use the same docker image to build the binaries as unit tests, jenkins will run docker-compose to mount a local host dir btfs-binary-releases for read/write access by the container and consumption by the jenkins job.  will also need to make a new branch based off release and merge there.