### PR TITLE
BTFS-937-release add docker-compose to build binaries

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3'
+services:
+  btfs-build-binaries:
+    build:
+      context: .
+      dockerfile: Dockerfile.unit_testing
+    volumes:
+      - ../btfs-binary-releases:/btfs-binary-releases
+    command:
+      bash -c "chmod 777 package.sh && ./package.sh"


### PR DESCRIPTION
here is the PR to merge to release branch.  jenkins will run docker-compose to build binaries to eliminate variability in the version of go.