### PR TITLE
BTFS-713: Storage upload command uses reed solomon encoded file

### DIFF
--- a/core/commands/storage.go
+++ b/core/commands/storage.go
@@ -187,8 +187,7 @@ Receive proofs as collateral evidence after selected nodes agree to store the fi
 			if err != nil {
 				return err
 			}
-			// The second child is always data root node
-			cids := nodes[1].Links()
+			cids := nodes.DataNode.Links()
 			if len(cids) != int(rsMeta.NumData+rsMeta.NumParity) {
 				return fmt.Errorf("file must be reed-solomon encoded: encoding scheme mismatch")
 			}

--- a/core/commands/storage.go
+++ b/core/commands/storage.go
@@ -81,15 +81,28 @@ var storageUploadCmd = &cmds.Command{
 	Helptext: cmds.HelpText{
 		Tagline: "Store files on BTFS network nodes through BTT payment.",
 		ShortDescription: `
-To upload and store a file on specific hosts:
-    use -m with 'custom' mode, and put host identifiers in -s, with multiple hosts separated by ','
+By default, BTFS will select hosts based on overall score according to current client's environment.
+To upload a file, <file-hash> must refer to a reed-solomon encoded file.
 
-For example:
+To create a reed-solomon encoded file from a normal file:
 
-    btfs storage upload <filehash> -m=custom -s=<host_address1>,<host_address2>
-    btfs storage upload <leafhash1> <leafhash2> -l -m=custom -s=<host_address1>,<host_address2>
+    $ btfs add --chunker=reed-solomon <file>
+    added <file-hash> <file>
 
-If no hosts are given, BTFS will select nodes based on overall score according to current client's environment.
+Run command to upload:
+
+    $ btfs storage upload <file-hash>
+
+To customly upload and store a file on specific hosts:
+    Use -m with 'custom' mode, and put host identifiers in -s, with multiple hosts separated by ','.
+
+    # Upload a file to a set of hosts
+    # Total # of hosts must match # of shards in the first DAG level of root file hash
+    $ btfs storage upload <file-hash> -m=custom -s=<host_address1>,<host_address2>
+
+    # Upload specific chunks to a set of hosts
+    # Total # of hosts must match # of chunks given
+    $ btfs storage upload <chunk-hash1> <chunk-hash2> -l -m=custom -s=<host_address1>,<host_address2>
 
 Receive proofs as collateral evidence after selected nodes agree to store the file.`,
 	},
@@ -101,7 +114,6 @@ Receive proofs as collateral evidence after selected nodes agree to store the fi
 		"proof":  storageUploadProofCmd,
 	},
 	Arguments: []cmds.Argument{
-		// FIXME: change file hash to limit 1
 		cmds.StringArg("file-hash", true, true, "Add hash of file to upload.").EnableStdin(),
 	},
 	Options: []cmds.Option{

--- a/core/coreunix/metadata.go
+++ b/core/coreunix/metadata.go
@@ -143,7 +143,7 @@ func GetDataForUserAndMeta(ctx context.Context, nd ipld.Node, ds ipld.DAGService
 		if childen == nil {
 			return nil, n.Data(), nil
 		}
-		return childen[1].(*dag.ProtoNode).Data(), childen[0].(*dag.ProtoNode).Data(), nil
+		return childen.DataNode.(*dag.ProtoNode).Data(), childen.MetaNode.(*dag.ProtoNode).Data(), nil
 	}
 
 	return n.Data(), nil, nil

--- a/core/hub/sync.go
+++ b/core/hub/sync.go
@@ -18,7 +18,7 @@ const (
 )
 
 var (
-	hubUrl = "https://query-btfs-dev.bt.co/hosts"
+	hubUrl = "https://query-dev.btfs.io/hosts"
 )
 
 type hostsQuery struct {

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/TRON-US/go-btfs-files v0.1.1
 	github.com/TRON-US/go-eccrypto v0.0.1
 	github.com/TRON-US/go-mfs v0.2.1
-	github.com/TRON-US/go-unixfs v0.4.6
+	github.com/TRON-US/go-unixfs v0.4.7
 	github.com/TRON-US/interface-go-btfs-core v0.4.2
 	github.com/Workiva/go-datastructures v1.0.50
 	github.com/blang/semver v3.5.1+incompatible

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/TRON-US/go-eccrypto v0.0.1
 	github.com/TRON-US/go-mfs v0.2.1
 	github.com/TRON-US/go-unixfs v0.4.6
-	github.com/TRON-US/interface-go-btfs-core v0.4.1
+	github.com/TRON-US/interface-go-btfs-core v0.4.2
 	github.com/Workiva/go-datastructures v1.0.50
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/bren2010/proquint v0.0.0-20160323162903-38337c27106d

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/StackExchange/wmi v0.0.0-20181212234831-e0a55b97c705 // indirect
 	github.com/TRON-US/go-btfs-chunker v0.2.3
 	github.com/TRON-US/go-btfs-cmds v0.1.5
-	github.com/TRON-US/go-btfs-config v0.1.8
+	github.com/TRON-US/go-btfs-config v0.1.9
 	github.com/TRON-US/go-btfs-files v0.1.1
 	github.com/TRON-US/go-eccrypto v0.0.1
 	github.com/TRON-US/go-mfs v0.2.1

--- a/go.sum
+++ b/go.sum
@@ -24,7 +24,6 @@ github.com/Stebalien/go-bitfield v0.0.1 h1:X3kbSSPUaJK60wV2hjOPZwmpljr6VGCqdq4cB
 github.com/Stebalien/go-bitfield v0.0.1/go.mod h1:GNjFpasyUVkHMsfEOk8EFLJ9syQ6SI+XWrX9Wf2XH0s=
 github.com/TRON-US/go-btfs-chunker v0.2.0 h1:dp80UzRmUFzDDDt4nqo2STGVh5I4jDQJRYJYtRGulSo=
 github.com/TRON-US/go-btfs-chunker v0.2.0/go.mod h1:6wFL7KgEumsn7R7IGFZZhOGIHxA/YkA4RdfR553M3Fk=
-github.com/TRON-US/go-btfs-chunker v0.2.2 h1:aiLDsiM3X2Yy2jVo3EQYYEVkw57SThOUPTs0Ja5yPeA=
 github.com/TRON-US/go-btfs-chunker v0.2.2/go.mod h1:Wj0oyybAWtu5lpcAc90QQ3bhJ14JRXD50PqxP25wmnI=
 github.com/TRON-US/go-btfs-chunker v0.2.3 h1:ky/HsQY8UU+Mas3qXptwO9x3Pd2HWDDm+ycpS+NI9Js=
 github.com/TRON-US/go-btfs-chunker v0.2.3/go.mod h1:Wj0oyybAWtu5lpcAc90QQ3bhJ14JRXD50PqxP25wmnI=
@@ -38,12 +37,10 @@ github.com/TRON-US/go-eccrypto v0.0.1 h1:+/5Uid61UGysbxv6Cv6gx4ru1gEiJOlir/P7ElA
 github.com/TRON-US/go-eccrypto v0.0.1/go.mod h1:QZqTUSKP9MdYh+0LPsnVKvXV/Q2f9Qb6V4ejvUmHVvI=
 github.com/TRON-US/go-mfs v0.2.1 h1:8M4F8eNdfRRW3iA4UM5V/Mki0BS9cmzuOefcBerOsP8=
 github.com/TRON-US/go-mfs v0.2.1/go.mod h1:++0mxQcc1Vjb49Tu3+SvIKfvY3HrC5onH5CctBf4iqQ=
-github.com/TRON-US/go-unixfs v0.3.0 h1:mbmSHVGZbkV5NVRuQHZ/Cw8BMta74GVeOY3TE76TvDE=
 github.com/TRON-US/go-unixfs v0.3.0/go.mod h1:t0JHRUZ0MbDhD1S5jNXByrkX1mfbftJ+0jE89+Bv044=
-github.com/TRON-US/go-unixfs v0.4.4 h1:EzTr7aHrB/vlAr4onYb/ENdsFt0NYNUGAefVD93r28w=
 github.com/TRON-US/go-unixfs v0.4.4/go.mod h1:VBRlISp23R6JoJQ2t+O/VkIswnPo9PBVCh5blMpN0GI=
-github.com/TRON-US/go-unixfs v0.4.6 h1:XpWXOdolCTZ4UOkLj3a73pJvHKAGqdR7cAH2x4+daow=
-github.com/TRON-US/go-unixfs v0.4.6/go.mod h1:+Llf5BXSKEaK4HHf1+/eehGwWsEUilNymR1N7a69Y9k=
+github.com/TRON-US/go-unixfs v0.4.7 h1:CDPFeHFnDfJd0amzyiqKgjLsv3XLnJJgXP9JUffPLYU=
+github.com/TRON-US/go-unixfs v0.4.7/go.mod h1:+Llf5BXSKEaK4HHf1+/eehGwWsEUilNymR1N7a69Y9k=
 github.com/TRON-US/interface-go-btfs-core v0.4.2 h1:uBKLYteSsSIOtXK9JMjbPNXgnUhtFBPUFHEwVEaN/F8=
 github.com/TRON-US/interface-go-btfs-core v0.4.2/go.mod h1:wZWJikVV3ShW7fClZP8/Gv8gYFg4ZowePkKBp0HY9Xc=
 github.com/Workiva/go-datastructures v1.0.50 h1:slDmfW6KCHcC7U+LP3DDBbm4fqTwZGn1beOFPfGaLvo=
@@ -311,7 +308,6 @@ github.com/ipfs/go-ipfs-blockstore v0.0.1 h1:O9n3PbmTYZoNhkgkEyrXTznbmktIXif62xL
 github.com/ipfs/go-ipfs-blockstore v0.0.1/go.mod h1:d3WClOmRQKFnJ0Jz/jj/zmksX0ma1gROTlovZKBmN08=
 github.com/ipfs/go-ipfs-blocksutil v0.0.1 h1:Eh/H4pc1hsvhzsQoMEP3Bke/aW5P5rVM1IWFJMcGIPQ=
 github.com/ipfs/go-ipfs-blocksutil v0.0.1/go.mod h1:Yq4M86uIOmxmGPUHv/uI7uKqZNtLb449gwKqXjIsnRk=
-github.com/ipfs/go-ipfs-chunker v0.0.1 h1:cHUUxKFQ99pozdahi+uSC/3Y6HeRpi9oTeUHbE27SEw=
 github.com/ipfs/go-ipfs-chunker v0.0.1/go.mod h1:tWewYK0we3+rMbOh7pPFGDyypCtvGcBFymgY4rSDLAw=
 github.com/ipfs/go-ipfs-config v0.0.5/go.mod h1:IGkVTacurWv9WFKc7IBPjHGM/7hi6+PEClqUb/l2BIM=
 github.com/ipfs/go-ipfs-config v0.0.6 h1:jzK9Tl8S0oWBir3F5ObtGgnHRPdqQ0MYiCmwXtV3Ps4=

--- a/go.sum
+++ b/go.sum
@@ -30,8 +30,8 @@ github.com/TRON-US/go-btfs-chunker v0.2.3 h1:ky/HsQY8UU+Mas3qXptwO9x3Pd2HWDDm+yc
 github.com/TRON-US/go-btfs-chunker v0.2.3/go.mod h1:Wj0oyybAWtu5lpcAc90QQ3bhJ14JRXD50PqxP25wmnI=
 github.com/TRON-US/go-btfs-cmds v0.1.5 h1:AbnAPBAFxe67MPChbwFPJbyKY1Vm3lXybGDNQ4NUTno=
 github.com/TRON-US/go-btfs-cmds v0.1.5/go.mod h1:rtki4vmPzq7qmjdzThJELFpSpxTiORoXreHlExdI6eg=
-github.com/TRON-US/go-btfs-config v0.1.8 h1:FrYhoesR/+dP4VR+VYgmu3QNenGT5v+mQph9VR+JevA=
-github.com/TRON-US/go-btfs-config v0.1.8/go.mod h1:SdSLMMxOxqLYvMI0eJItYH7mWkG22EX5WaGyUwOq3fU=
+github.com/TRON-US/go-btfs-config v0.1.9 h1:xJbPSljAfL0cgU0ydW8ZReo23/CIayFG6oPGBTTk3Tk=
+github.com/TRON-US/go-btfs-config v0.1.9/go.mod h1:SdSLMMxOxqLYvMI0eJItYH7mWkG22EX5WaGyUwOq3fU=
 github.com/TRON-US/go-btfs-files v0.1.1 h1:GuDIiWDM66bfhfxJy8+dBL4Cfbcp3iBp7pgHpKKCw8k=
 github.com/TRON-US/go-btfs-files v0.1.1/go.mod h1:tD2vOKLcLCDNMn9rrA27n2VbNpHdKewGzEguIFY+EJ0=
 github.com/TRON-US/go-eccrypto v0.0.1 h1:+/5Uid61UGysbxv6Cv6gx4ru1gEiJOlir/P7ElAe7A0=

--- a/go.sum
+++ b/go.sum
@@ -44,8 +44,8 @@ github.com/TRON-US/go-unixfs v0.4.4 h1:EzTr7aHrB/vlAr4onYb/ENdsFt0NYNUGAefVD93r2
 github.com/TRON-US/go-unixfs v0.4.4/go.mod h1:VBRlISp23R6JoJQ2t+O/VkIswnPo9PBVCh5blMpN0GI=
 github.com/TRON-US/go-unixfs v0.4.6 h1:XpWXOdolCTZ4UOkLj3a73pJvHKAGqdR7cAH2x4+daow=
 github.com/TRON-US/go-unixfs v0.4.6/go.mod h1:+Llf5BXSKEaK4HHf1+/eehGwWsEUilNymR1N7a69Y9k=
-github.com/TRON-US/interface-go-btfs-core v0.4.1 h1:NR/nmREHANxl7GACzcFHoonCP0hpa3ItlXHhyxvd3IE=
-github.com/TRON-US/interface-go-btfs-core v0.4.1/go.mod h1:wZWJikVV3ShW7fClZP8/Gv8gYFg4ZowePkKBp0HY9Xc=
+github.com/TRON-US/interface-go-btfs-core v0.4.2 h1:uBKLYteSsSIOtXK9JMjbPNXgnUhtFBPUFHEwVEaN/F8=
+github.com/TRON-US/interface-go-btfs-core v0.4.2/go.mod h1:wZWJikVV3ShW7fClZP8/Gv8gYFg4ZowePkKBp0HY9Xc=
 github.com/Workiva/go-datastructures v1.0.50 h1:slDmfW6KCHcC7U+LP3DDBbm4fqTwZGn1beOFPfGaLvo=
 github.com/Workiva/go-datastructures v1.0.50/go.mod h1:Z+F2Rca0qCsVYDS8z7bAGm8f3UkzuWYS/oBZz5a7VVA=
 github.com/aead/siphash v1.0.1/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBAUSII=

--- a/spin/analytics.go
+++ b/spin/analytics.go
@@ -233,15 +233,10 @@ func (dc *dataCollection) sendData(node *core.IpfsNode) {
 
 func (dc *dataCollection) collectionAgent(node *core.IpfsNode) {
 	tick := time.NewTicker(heartBeat)
-
 	defer tick.Stop()
-
-	config, _ := dc.node.Repo.Config()
-	if config.Experimental.Analytics {
-		dc.sendData(node)
-	}
+	// Force tick on immediate start
 	// make the configuration available in the for loop
-	for range tick.C {
+	for ; true; <-tick.C {
 		config, _ := dc.node.Repo.Config()
 		// check config for explicit consent to data collect
 		// consent can be changed without reinitializing data collection

--- a/spin/hosts.go
+++ b/spin/hosts.go
@@ -30,7 +30,8 @@ func Hosts(node *core.IpfsNode) {
 func perodicSyncHosts(node *core.IpfsNode, mode string) {
 	tick := time.NewTicker(syncPeriod)
 	defer tick.Stop()
-	for range tick.C {
+	// Force tick on immediate start
+	for ; true; <-tick.C {
 		err := commands.SyncHosts(node, mode)
 		if err != nil {
 			log.Errorf("Failed to sync hosts: %s", err)


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The subject of this PR contains a JIRA ticket BTFS-xxxx (N/A for community PRs)
- [x] PR description and commit messages are [good and meaningful](https://chris.beams.io/posts/git-commit/)
- [x] Unit tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

* **Please make sure the following procedures have been applied before requesting reviewers**
- [x] Code changes closely follow [Go Code Review Comments](https://github.com/golang/go/wiki/CodeReviewComments)
- [x] Code has been *rebased* against latest master (`git merge` not recommended, unless you know what you are doing)
- [x] Code changes have run through `go fmt`
- [x] Code changes have run through `go mod tidy`
- [x] All unit tests passed locally (`make test_go_test`) 

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

  New feature / change: now `btfs storage upload <file-hash>` must be a reed solomon encoded file

* **What is the current behavior?** (You can also link to an open issue here)

  Storage upload flow can take any file / chunks to upload to hosts

* **What is the new behavior?** (You can also refer to a JIRA ticket here)

  Storage upload flow must use reed solomon encoded file - must pass validation

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

  N/A (unreleased command)

* **What dependencies / modules need to be updated as pre-requisites?** (Include relevant PR links here)

  Updated the following:
  https://github.com/TRON-US/interface-go-btfs-core/pull/15
  https://github.com/TRON-US/go-btfs-config/pull/14
  https://github.com/TRON-US/go-unixfs/pull/13

* **Description of changes**
  - Update storage upload helptext to include new changes and clarify custom command behavior
  - Handle mismatched custom hosts and throw error before continuing in storage upload flow
  - Check reed solomon metadata info and resolve the shard hashes to pass to storage hosts
  - Fixed an issue with hosts syncing to start immediately on daemon startup