### PR TITLE
BTFS-1004: Prep guard challenges (part 1)

### DIFF
--- a/core/commands/storage/challenge_test.go
+++ b/core/commands/storage/challenge_test.go
@@ -5,39 +5,62 @@ import (
 	"testing"
 
 	unixtest "github.com/TRON-US/go-btfs/core/coreunix/test"
+
+	unixfs "github.com/TRON-US/go-unixfs"
+	path "github.com/TRON-US/interface-go-btfs-core/path"
 )
 
 func TestGenAndSolveChallenge(t *testing.T) {
 	node, api, root := unixtest.HelpTestAddWithReedSolomonMetadata(t)
 
-	sc, err := NewStorageChallenge(context.Background(), node, api, root)
+	// Resolve file root node
+	rn, err := api.ResolveNode(context.Background(), path.IpfsPath(root))
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	// simulate 100 different challenges for the same file
-	chs := map[string]bool{}
-	for i := 0; i < 100; i++ {
-		err := sc.GenChallenge()
+	// Get sharded root node (strip away metadata)
+	nodes, err := unixfs.GetChildrenForDagWithMeta(context.Background(), rn, api.Dag())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Check all shards under reed solomon
+	for _, link := range nodes.DataNode.Links() {
+		sid := link.Cid
+		// simulate client challenge gen
+		sc, err := NewStorageChallenge(context.Background(), node, api, sid)
+		if err != nil {
+			t.Fatal(err)
+		}
+		// simulate host challenge preparation
+		scr, err := NewStorageChallengeResponse(context.Background(), node, api, sid, sc.ID)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		// should not re-generate duplicate challenges
-		if _, ok := chs[sc.Hash]; ok {
-			t.Fatal("Duplicate challenge generated")
-		}
-		chs[sc.Hash] = true
+		// simulate 100 different challenges per shard
+		chs := map[string]bool{}
+		for i := 0; i < 100; i++ {
+			err := sc.GenChallenge()
+			if err != nil {
+				t.Fatal(err)
+			}
 
-		scr := NewStorageChallengeResponse(context.Background(), node, api, sc.ID)
+			// should not re-generate duplicate challenges
+			if _, ok := chs[sc.Hash]; ok {
+				t.Fatal("Duplicate challenge generated")
+			}
+			chs[sc.Hash] = true
 
-		err = scr.SolveChallenge(sc.CID, sc.Nonce)
-		if err != nil {
-			t.Fatal(err)
-		}
+			err = scr.SolveChallenge(sc.CIndex, sc.Nonce)
+			if err != nil {
+				t.Fatal(err)
+			}
 
-		if scr.Hash != sc.Hash {
-			t.Fatal("Challenge is not solved, not matching original hash")
+			if scr.Hash != sc.Hash {
+				t.Fatal("Challenge is not solved, not matching original hash")
+			}
 		}
 	}
 }


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

  Feature: send challenge questions from renter to guard

* **What is the current behavior?** (You can also link to an open issue here)

  Challenge was using old chunk hash + nonce generation method

* **What is the new behavior?** (You can also refer to a JIRA ticket here)

  Challenge now generates chunk index + nonce and updates existing code and tests

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

  Yes - but no one is using the /storage/upload apis yet

* **What dependencies / modules need to be updated as pre-requisites?** (Include relevant PR links here)

* **Description of changes**
  - Use chunk index instead of chunk id for DAG verification
  - Save shard hash instead of file hash
  - Challenge response needs shard hash in order to compute the chunk id
  - Fix /storage/upload/reqc by using ChunkIndex instead of ChunkHash
  - Fix a bug that reqc always returns the answer Hash and respc always solves the question with the gotten answer

---

* **Please check if the PR fulfills these requirements**
- [x] The subject of this PR contains a JIRA ticket BTFS-xxxx (N/A for community PRs)
- [x] PR description and commit messages are [good and meaningful](https://chris.beams.io/posts/git-commit/)
- [x] Unit tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **Please make sure the following procedures have been applied before requesting reviewers**
- [x] Code changes closely follow [Go Code Review Comments](https://github.com/golang/go/wiki/CodeReviewComments)
- [x] Code has been *rebased* against latest master (`git merge` not recommended, unless you know what you are doing)
- [x] Code changes have run through `go fmt`
- [x] Code changes have run through `go mod tidy`
- [x] All unit tests passed locally (`make test_go_test`)
