### PR TITLE
[BTFS-1121] fix: missing --dc flag overwrite config issue

### DIFF
--- a/cmd/btfs/daemon.go
+++ b/cmd/btfs/daemon.go
@@ -184,7 +184,7 @@ Headers.
 		cmds.BoolOption(enableIPNSPubSubKwd, "Enable BTNS record distribution through pubsub; enables pubsub."),
 		cmds.BoolOption(enableMultiplexKwd, "Add the experimental 'go-multiplex' stream muxer to libp2p on construction.").WithDefault(true),
 		cmds.StringOption(hValuekwd, "The h value identifying the hosting bit torrent client"),
-		cmds.BoolOption(enableDataCollection, "Allow BTFS to collect and send out node statistics."),
+		cmds.BoolOption(enableDataCollection, "Allow BTFS to collect and send out node statistics.").WithDefault(nil),
 		cmds.BoolOption(enableStartupTest, "Allow BTFS to perform start up test.").WithDefault(false),
 
 		// TODO: add way to override addresses. tricky part: updating the config if also --init.
@@ -446,8 +446,10 @@ func daemonFunc(req *cmds.Request, re cmds.ResponseEmitter, env cmds.Environment
 	}
 
 	//Begin sending analytics to hosted server
-	collectData, _ := req.Options[enableDataCollection].(bool)
-	node.Repo.SetConfigKey("Experimental.Analytics", collectData)
+	// set Analytics flag if specified
+	if dc, ok := req.Options[enableDataCollection]; ok == true {
+		node.Repo.SetConfigKey("Experimental.Analytics", dc)
+	}
 	analytics.Initialize(node, version.CurrentVersionNumber, hValue)
 
 	// Give the user some immediate feedback when they hit C-c

--- a/cmd/btfs/daemon.go
+++ b/cmd/btfs/daemon.go
@@ -184,7 +184,7 @@ Headers.
 		cmds.BoolOption(enableIPNSPubSubKwd, "Enable BTNS record distribution through pubsub; enables pubsub."),
 		cmds.BoolOption(enableMultiplexKwd, "Add the experimental 'go-multiplex' stream muxer to libp2p on construction.").WithDefault(true),
 		cmds.StringOption(hValuekwd, "The h value identifying the hosting bit torrent client"),
-		cmds.BoolOption(enableDataCollection, "Allow BTFS to collect and send out node statistics.").WithDefault(nil),
+		cmds.BoolOption(enableDataCollection, "Allow BTFS to collect and send out node statistics."),
 		cmds.BoolOption(enableStartupTest, "Allow BTFS to perform start up test.").WithDefault(false),
 
 		// TODO: add way to override addresses. tricky part: updating the config if also --init.


### PR DESCRIPTION
* **What kind of change does this PR introduce?** 
Bug fix

* **What is the current behavior?** (You can also link to an open issue here)
--dc flag overwrites config(analytics=false) if not given

* **What is the new behavior?** (You can also refer to a JIRA ticket here)
--dc flag only overwrites config(analytics) if specified
https://tronnetwork.atlassian.net/browse/BTFS-1121

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
no

* **What dependencies / modules need to be updated as pre-requisites?** (Include relevant PR links here)
no
* **Description of changes**


---

* **Please check if the PR fulfills these requirements**
- [x] The subject of this PR contains a JIRA ticket BTFS-xxxx (N/A for community PRs)
- [x] PR description and commit messages are [good and meaningful](https://chris.beams.io/posts/git-commit/)
- [ ] Unit tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **Please make sure the following procedures have been applied before requesting reviewers**
- [x] Code changes closely follow [Go Code Review Comments](https://github.com/golang/go/wiki/CodeReviewComments)
- [x] Code has been *rebased* against latest master (`git merge` not recommended, unless you know what you are doing)
- [x] Code changes have run through `go fmt`
- [x] Code changes have run through `go mod tidy`
- [x] All unit tests passed locally (`make test_go_test`)
