### PR TITLE
[BTFS-1155]Updating the latest WebUI Hash

### DIFF
--- a/core/corehttp/webui.go
+++ b/core/corehttp/webui.go
@@ -1,6 +1,6 @@
 package corehttp
 
-const WebUIPath = "/btfs/QmTfM7Rz58Ejwq8Yg3jEEhtLc3BBxucpATiq4pRCy6TK4J"
+const WebUIPath = "/btfs/QmPCfG86C3e4UgxFm8hWq8ccQVJDwntLfvCrs3yT3kdKsy"
 
 // this is a list of all past webUI paths.
 var WebUIPaths = []string{

--- a/version.go
+++ b/version.go
@@ -4,6 +4,6 @@ package ipfs
 var CurrentCommit string
 
 // CurrentVersionNumber is the current application's version literal
-const CurrentVersionNumber = "0.2.2"
+const CurrentVersionNumber = "0.2.3"
 
 const ApiVersion = "/go-ipfs/" + CurrentVersionNumber + "/"


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This PR updates go-btfs version and also the new hash value of the WebUI build folder. 

* **What is the current behavior?** (You can also link to an open issue here)
Old go-btfs version as well as old WebUI build folder hash. 

* **What is the new behavior?** (You can also refer to a JIRA ticket here)
New go-btfs version and new WebUI build folder hash. 

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Not sure if it's a breaking change, but updating go-btfs version will trigger autoupdate later. 

* **What dependencies / modules need to be updated as pre-requisites?** (Include relevant PR links here)
None

* **Description of changes**
Update go-btfs version and WebUI hash. 

---

* **Please check if the PR fulfills these requirements**
- [x] The subject of this PR contains a JIRA ticket BTFS-xxxx (N/A for community PRs)
- [x] PR description and commit messages are [good and meaningful](https://chris.beams.io/posts/git-commit/)
- [ ] Unit tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **Please make sure the following procedures have been applied before requesting reviewers**
- [ ] Code changes closely follow [Go Code Review Comments](https://github.com/golang/go/wiki/CodeReviewComments)
- [ ] Code has been *rebased* against latest master (`git merge` not recommended, unless you know what you are doing)
- [ ] Code changes have run through `go fmt`
- [ ] Code changes have run through `go mod tidy`
- [ ] All unit tests passed locally (`make test_go_test`)
