### PR TITLE
Update go-btfs-chunker to fix reed solomon chunker issue during offline

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,13 +7,13 @@ require (
 	github.com/Kubuxu/gocovmerge v0.0.0-20161216165753-7ecaa51963cd
 	github.com/StackExchange/wmi v0.0.0-20181212234831-e0a55b97c705 // indirect
 	github.com/TRON-US/go-btfs-api v0.1.0
-	github.com/TRON-US/go-btfs-chunker v0.2.4
+	github.com/TRON-US/go-btfs-chunker v0.2.5
 	github.com/TRON-US/go-btfs-cmds v0.1.5
 	github.com/TRON-US/go-btfs-config v0.2.1
 	github.com/TRON-US/go-btfs-files v0.1.1
 	github.com/TRON-US/go-eccrypto v0.0.1
 	github.com/TRON-US/go-mfs v0.2.2
-	github.com/TRON-US/go-unixfs v0.4.12
+	github.com/TRON-US/go-unixfs v0.4.13
 	github.com/TRON-US/interface-go-btfs-core v0.4.3
 	github.com/Workiva/go-datastructures v1.0.50
 	github.com/blang/semver v3.5.1+incompatible

--- a/go.sum
+++ b/go.sum
@@ -29,6 +29,8 @@ github.com/TRON-US/go-btfs-chunker v0.2.3 h1:ky/HsQY8UU+Mas3qXptwO9x3Pd2HWDDm+yc
 github.com/TRON-US/go-btfs-chunker v0.2.3/go.mod h1:Wj0oyybAWtu5lpcAc90QQ3bhJ14JRXD50PqxP25wmnI=
 github.com/TRON-US/go-btfs-chunker v0.2.4 h1:3dw5plmhDoI8QkzAbgkNHm5WbBsRWrjifjrHK5EP34s=
 github.com/TRON-US/go-btfs-chunker v0.2.4/go.mod h1:Wj0oyybAWtu5lpcAc90QQ3bhJ14JRXD50PqxP25wmnI=
+github.com/TRON-US/go-btfs-chunker v0.2.5 h1:mU4iu2jYs89PtIO5vnJwqZHUgx/gwV0z8RFHmZNDS1U=
+github.com/TRON-US/go-btfs-chunker v0.2.5/go.mod h1:Wj0oyybAWtu5lpcAc90QQ3bhJ14JRXD50PqxP25wmnI=
 github.com/TRON-US/go-btfs-cmds v0.1.5 h1:AbnAPBAFxe67MPChbwFPJbyKY1Vm3lXybGDNQ4NUTno=
 github.com/TRON-US/go-btfs-cmds v0.1.5/go.mod h1:rtki4vmPzq7qmjdzThJELFpSpxTiORoXreHlExdI6eg=
 github.com/TRON-US/go-btfs-config v0.2.1 h1:VEJojgve8JfsbPvKJ882KCn4JO6BthrJOkW6b2tzMg4=
@@ -42,6 +44,8 @@ github.com/TRON-US/go-mfs v0.2.2/go.mod h1:NduHl3CtI8J81aY4aV/Si/9XZbZ/+hHzPZUHC
 github.com/TRON-US/go-unixfs v0.4.4/go.mod h1:VBRlISp23R6JoJQ2t+O/VkIswnPo9PBVCh5blMpN0GI=
 github.com/TRON-US/go-unixfs v0.4.12 h1:8u8D6JQPngXKGHPgq98+TLPaSjCx/QtYipiuP/MtOtg=
 github.com/TRON-US/go-unixfs v0.4.12/go.mod h1:0Jv/z5OvpB4JpjJcUFB9turYohcoqjF/tmczQX9eeJ4=
+github.com/TRON-US/go-unixfs v0.4.13 h1:Ck55atVfRY4IIHEKlRFI/z+Z3qcYCNG34QmLMQgECNU=
+github.com/TRON-US/go-unixfs v0.4.13/go.mod h1:m/qCevblRIFFCxTHlKtljACjCIYV6nOivzx+jh0nOQU=
 github.com/TRON-US/interface-go-btfs-core v0.4.3 h1:Ld/6GhCElyaQsBPdIU0DkZWdWzXvscnhUTAxWLBcuJ8=
 github.com/TRON-US/interface-go-btfs-core v0.4.3/go.mod h1:wZWJikVV3ShW7fClZP8/Gv8gYFg4ZowePkKBp0HY9Xc=
 github.com/Workiva/go-datastructures v1.0.50 h1:slDmfW6KCHcC7U+LP3DDBbm4fqTwZGn1beOFPfGaLvo=


### PR DESCRIPTION
btfs add

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

  Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

  `btfs add --chunker=reed-solomon` hangs for large files in offline mode

* **What is the new behavior?** (You can also refer to a JIRA ticket here)

  The above bug is fixed

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)


* **What dependencies / modules need to be updated as pre-requisites?** (Include relevant PR links here)

  https://github.com/TRON-US/go-btfs-chunker/pull/8
  https://github.com/TRON-US/go-unixfs/pull/19

* **Description of changes**
  - Add a read check at the end of the stream of reed solomon chunker so that it always finishes reading the file stream (in go-btfs-chunker change).

---

* **Please check if the PR fulfills these requirements**
- [ ] The subject of this PR contains a JIRA ticket BTFS-xxxx (N/A for community PRs)
- [x] PR description and commit messages are [good and meaningful](https://chris.beams.io/posts/git-commit/)
- [ ] Unit tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **Please make sure the following procedures have been applied before requesting reviewers**
- [x] Code changes closely follow [Go Code Review Comments](https://github.com/golang/go/wiki/CodeReviewComments)
- [x] Code has been *rebased* against latest master (`git merge` not recommended, unless you know what you are doing)
- [x] Code changes have run through `go fmt`
- [x] Code changes have run through `go mod tidy`
- [x] All unit tests passed locally (`make test_go_test`)
