### PR TITLE
BTFS-1141: Reed Solomon based operations w/ per file replication unit

### DIFF
--- a/core/coreunix/add.go
+++ b/core/coreunix/add.go
@@ -123,13 +123,18 @@ func (adder *Adder) add(reader io.Reader) (ipld.Node, error) {
 			return nil, err
 		}
 	}
-	// Only append metadata if it's available
-	if md := chnk.MetaData(); md != nil {
-		metaBytes, err = adder.appendMetadataObject(metaBytes, md)
-		if err != nil {
-			return nil, err
+	// This `if conditional statement` makes sure this block is
+	// executed only one time for directory addition use case.
+	if adder.MetadataDag == nil {
+		// Only append metadata if it's available
+		if md := chnk.MetaData(); md != nil {
+			metaBytes, err = adder.appendMetadataObject(metaBytes, md)
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
+
 	// Add SuperMeta if metaBytes is not nil
 	chunkSize := chnk.ChunkSize()
 	if chunkSize == 0 {

--- a/core/coreunix/test/metadata_test.go
+++ b/core/coreunix/test/metadata_test.go
@@ -196,7 +196,7 @@ func addDirectoryToBtfs(node *core.IpfsNode, file files.Node, metadata string, r
 		}
 	}
 	if rs {
-		dsize, psize, csize := 10, 20, 262144
+		dsize, psize, csize := TestRsDataSize, TestRsParitySize, 262144
 		adder.Chunker = fmt.Sprintf("reed-solomon-%d-%d-%d", dsize, psize, csize)
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -10,10 +10,10 @@ require (
 	github.com/TRON-US/go-btfs-chunker v0.2.5
 	github.com/TRON-US/go-btfs-cmds v0.1.5
 	github.com/TRON-US/go-btfs-config v0.2.1
-	github.com/TRON-US/go-btfs-files v0.1.1
+	github.com/TRON-US/go-btfs-files v0.1.2
 	github.com/TRON-US/go-eccrypto v0.0.1
 	github.com/TRON-US/go-mfs v0.2.2
-	github.com/TRON-US/go-unixfs v0.4.13
+	github.com/TRON-US/go-unixfs v0.4.14
 	github.com/TRON-US/interface-go-btfs-core v0.4.3
 	github.com/Workiva/go-datastructures v1.0.50
 	github.com/blang/semver v3.5.1+incompatible

--- a/go.sum
+++ b/go.sum
@@ -37,6 +37,8 @@ github.com/TRON-US/go-btfs-config v0.2.1 h1:VEJojgve8JfsbPvKJ882KCn4JO6BthrJOkW6
 github.com/TRON-US/go-btfs-config v0.2.1/go.mod h1:SdSLMMxOxqLYvMI0eJItYH7mWkG22EX5WaGyUwOq3fU=
 github.com/TRON-US/go-btfs-files v0.1.1 h1:GuDIiWDM66bfhfxJy8+dBL4Cfbcp3iBp7pgHpKKCw8k=
 github.com/TRON-US/go-btfs-files v0.1.1/go.mod h1:tD2vOKLcLCDNMn9rrA27n2VbNpHdKewGzEguIFY+EJ0=
+github.com/TRON-US/go-btfs-files v0.1.2 h1:iXaPv9w5zND7rFbjRzX7kP7TEWr4G3Y1h4inslEtyxk=
+github.com/TRON-US/go-btfs-files v0.1.2/go.mod h1:WbnH7HFFolwxJyzuZlE2qWBJfCCVczzpRQwerYIZApM=
 github.com/TRON-US/go-eccrypto v0.0.1 h1:+/5Uid61UGysbxv6Cv6gx4ru1gEiJOlir/P7ElAe7A0=
 github.com/TRON-US/go-eccrypto v0.0.1/go.mod h1:QZqTUSKP9MdYh+0LPsnVKvXV/Q2f9Qb6V4ejvUmHVvI=
 github.com/TRON-US/go-mfs v0.2.2 h1:EUlDvvSo8HKso4oy05Ce8ZG6arASAdirV2BzAYfKTsM=
@@ -46,6 +48,8 @@ github.com/TRON-US/go-unixfs v0.4.12 h1:8u8D6JQPngXKGHPgq98+TLPaSjCx/QtYipiuP/Mt
 github.com/TRON-US/go-unixfs v0.4.12/go.mod h1:0Jv/z5OvpB4JpjJcUFB9turYohcoqjF/tmczQX9eeJ4=
 github.com/TRON-US/go-unixfs v0.4.13 h1:Ck55atVfRY4IIHEKlRFI/z+Z3qcYCNG34QmLMQgECNU=
 github.com/TRON-US/go-unixfs v0.4.13/go.mod h1:m/qCevblRIFFCxTHlKtljACjCIYV6nOivzx+jh0nOQU=
+github.com/TRON-US/go-unixfs v0.4.14 h1:M+FeKP0LX1fKdbN+dWYAM1vK/1X8OB6kdijsZlumnXI=
+github.com/TRON-US/go-unixfs v0.4.14/go.mod h1:m/qCevblRIFFCxTHlKtljACjCIYV6nOivzx+jh0nOQU=
 github.com/TRON-US/interface-go-btfs-core v0.4.3 h1:Ld/6GhCElyaQsBPdIU0DkZWdWzXvscnhUTAxWLBcuJ8=
 github.com/TRON-US/interface-go-btfs-core v0.4.3/go.mod h1:wZWJikVV3ShW7fClZP8/Gv8gYFg4ZowePkKBp0HY9Xc=
 github.com/Workiva/go-datastructures v1.0.50 h1:slDmfW6KCHcC7U+LP3DDBbm4fqTwZGn1beOFPfGaLvo=


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
BTFS-1141: Reed Solomon based operations on 2-level directory object with metadata should work.

* **What is the current behavior?** (You can also link to an open issue here)
"btfs add -m $metadata-string $directory" on directory does not attach metadata under the given directory.

* **What is the new behavior?** (You can also refer to a JIRA ticket here)
"btfs add -m $metadata-string $directory" attach metadata as child under the given directory.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
N/A

* **What dependencies / modules need to be updated as pre-requisites?** (Include relevant PR links here)
https://github.com/TRON-US/go-btfs-files/pull/3
https://github.com/TRON-US/go-unixfs/pull/20

* **Description of changes**
1. Modified add.go to make Reead-Solomon on directory work
2. Modified metadata_test.go to add new unit tests and to modify existing tests to be correct.


---

* **Please check if the PR fulfills these requirements**
- [x ] The subject of this PR contains a JIRA ticket BTFS-xxxx (N/A for community PRs)
- [x] PR description and commit messages are [good and meaningful](https://chris.beams.io/posts/git-commit/)
- [x] Unit tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **Please make sure the following procedures have been applied before requesting reviewers**
- [x ] Code changes closely follow [Go Code Review Comments](https://github.com/golang/go/wiki/CodeReviewComments)
- [x ] Code has been *rebased* against latest master (`git merge` not recommended, unless you know what you are doing)
- [x ] Code changes have run through `go fmt`
- [x ] Code changes have run through `go mod tidy`
- [x ] All unit tests passed locally (`make test_go_test`)
