### PR TITLE
feat: get from remote when storage announce first time

### DIFF
--- a/core/commands/storage.go
+++ b/core/commands/storage.go
@@ -1269,10 +1269,9 @@ This command updates host information and broadcasts to the BTFS network.`,
 		rds := n.Repo.Datastore()
 		peerId := n.Identity.Pretty()
 
+		ns := new(hubpb.SettingsData)
 		selfKey := storage.GetHostStorageKey(peerId)
 		b, err := rds.Get(selfKey)
-
-		ns := new(hubpb.SettingsData)
 		if err == ds.ErrNotFound {
 			// If key not found, get from remote
 			if n, err := GetSettings(req.Context, cfg.Services.HubDomain, peerId, rds); err != nil {

--- a/core/commands/storage.go
+++ b/core/commands/storage.go
@@ -54,6 +54,8 @@ const (
 	// retry limit
 	RetryLimit = 3
 	FailLimit  = 3
+
+	bttTotalSupply = 990_000_000_000
 )
 
 // TODO: get/set the value from/in go-btfs-common
@@ -1268,6 +1270,10 @@ This command updates host information and broadcasts to the BTFS network.`,
 		cp, cpFound := req.Options[hostCollateralPriceOptionName].(uint64)
 		bl, blFound := req.Options[hostBandwidthLimitOptionName].(float64)
 		stm, stmFound := req.Options[hostStorageTimeMinOptionName].(uint64)
+
+		if sp > bttTotalSupply || cp > bttTotalSupply {
+			return fmt.Errorf("maximum price is %d", bttTotalSupply)
+		}
 
 		n, err := cmdenv.GetNode(env)
 		if err != nil {

--- a/core/commands/storage.go
+++ b/core/commands/storage.go
@@ -1271,7 +1271,7 @@ This command updates host information and broadcasts to the BTFS network.`,
 		bl, blFound := req.Options[hostBandwidthLimitOptionName].(float64)
 		stm, stmFound := req.Options[hostStorageTimeMinOptionName].(uint64)
 
-		if sp > bttTotalSupply || cp > bttTotalSupply {
+		if sp > bttTotalSupply || cp > bttTotalSupply || bp > bttTotalSupply {
 			return fmt.Errorf("maximum price is %d", bttTotalSupply)
 		}
 

--- a/core/commands/storage.go
+++ b/core/commands/storage.go
@@ -1219,6 +1219,9 @@ func GetSettings(ctx context.Context, addr string, peerId string, rds ds.Datasto
 		req := new(hubpb.SettingsReq)
 		req.Id = peerId
 		resp, err := client.GetSettings(ctx, req)
+		if err != nil {
+			return err
+		}
 		ns.StorageTimeMin = uint64(resp.SettingsData.StorageTimeMin)
 		ns.StoragePriceAsk = uint64(resp.SettingsData.StoragePriceAsk)
 		ns.BandwidthLimit = resp.SettingsData.BandwidthLimit

--- a/go.mod
+++ b/go.mod
@@ -141,4 +141,4 @@ require (
 	launchpad.net/gocheck v0.0.0-20140225173054-000000000087 // indirect
 )
 
-go 1.12
+go 1.13

--- a/spin/hosts.go
+++ b/spin/hosts.go
@@ -24,11 +24,11 @@ func Hosts(node *core.IpfsNode) {
 		m := configuration.Experimental.HostsSyncMode
 		fmt.Printf("Hosts info will be synced at [%s] mode\n", m)
 
-		go perodicSyncHosts(node, m)
+		go periodicSyncHosts(node, m)
 	}
 }
 
-func perodicSyncHosts(node *core.IpfsNode, mode string) {
+func periodicSyncHosts(node *core.IpfsNode, mode string) {
 	tick := time.NewTicker(syncPeriod)
 	defer tick.Stop()
 	// Force tick on immediate start


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature

* **What is the current behavior?** (You can also link to an open issue here)


* **What is the new behavior?** (You can also refer to a JIRA ticket here)
get from remote when storage announce first time

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)


* **What dependencies / modules need to be updated as pre-requisites?** (Include relevant PR links here)

* **Description of changes**


---

* **Please check if the PR fulfills these requirements**
- [x] The subject of this PR contains a JIRA ticket BTFS-xxxx (N/A for community PRs)
- [ ] PR description and commit messages are [good and meaningful](https://chris.beams.io/posts/git-commit/)
- [x] Unit tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **Please make sure the following procedures have been applied before requesting reviewers**
- [x] Code changes closely follow [Go Code Review Comments](https://github.com/golang/go/wiki/CodeReviewComments)
- [x] Code has been *rebased* against latest master (`git merge` not recommended, unless you know what you are doing)
- [x] Code changes have run through `go fmt`
- [x] Code changes have run through `go mod tidy`
- [ ] All unit tests passed locally (`make test_go_test`)
