### PR TITLE
BTFS-1207: Pass hval to auto updating process and refactor

### DIFF
--- a/cmd/btfs/autoupdate.go
+++ b/cmd/btfs/autoupdate.go
@@ -46,7 +46,7 @@ type Repo struct {
 }
 
 // Auto update function.
-func update(url string) {
+func update(url, hval string) {
 	// Get current program execution path.
 	defaultBtfsPath, err := getCurrentPath()
 	if err != nil {
@@ -283,24 +283,17 @@ func update(url string) {
 			continue
 		}
 
-		if runtime.GOOS == "windows" {
-			// Start the btfs-updater binary process.
-			cmd := exec.Command(updateBinaryPath, "-url", url, "-project", fmt.Sprint(defaultBtfsPath, "\\"),
-				"-download", fmt.Sprint(defaultBtfsPath, "\\"))
-			err = cmd.Start()
-			if err != nil {
-				log.Error(err)
-				continue
-			}
-		} else {
-			// Start the btfs-updater binary process.
-			cmd := exec.Command(updateBinaryPath, "-url", url, "-project", fmt.Sprint(defaultBtfsPath, "/"),
-				"-download", fmt.Sprint(defaultBtfsPath, "/"))
-			err = cmd.Start()
-			if err != nil {
-				log.Error(err)
-				continue
-			}
+		// Start the btfs-updater binary process.
+		cmd := exec.Command(updateBinaryPath,
+			"-url", url,
+			"-project", defaultBtfsPath+string(os.PathSeparator),
+			"-download", defaultBtfsPath+string(os.PathSeparator),
+			"-hval", hval,
+		)
+		err = cmd.Start()
+		if err != nil {
+			log.Error(err)
+			continue
 		}
 		fmt.Println("Process will exit now and restart after the update completes.")
 		os.Exit(0)

--- a/cmd/btfs/daemon.go
+++ b/cmd/btfs/daemon.go
@@ -62,7 +62,7 @@ const (
 	enablePubSubKwd           = "enable-pubsub-experiment"
 	enableIPNSPubSubKwd       = "enable-namesys-pubsub"
 	enableMultiplexKwd        = "enable-mplex-experiment"
-	hValuekwd                 = "hval"
+	hValueKwd                 = "hval"
 	enableDataCollection      = "dc"
 	enableStartupTest         = "enable-startup-test"
 	// apiAddrKwd    = "address-api"
@@ -184,7 +184,7 @@ Headers.
 		cmds.BoolOption(enablePubSubKwd, "Instantiate the btfs daemon with the experimental pubsub feature enabled."),
 		cmds.BoolOption(enableIPNSPubSubKwd, "Enable BTNS record distribution through pubsub; enables pubsub."),
 		cmds.BoolOption(enableMultiplexKwd, "Add the experimental 'go-multiplex' stream muxer to libp2p on construction.").WithDefault(true),
-		cmds.StringOption(hValuekwd, "The h value identifying the hosting bit torrent client"),
+		cmds.StringOption(hValueKwd, "H-value identifies the BitTorrent client this daemon is started by. None if not started by a BitTorrent client."),
 		cmds.BoolOption(enableDataCollection, "Allow BTFS to collect and send out node statistics."),
 		cmds.BoolOption(enableStartupTest, "Allow BTFS to perform start up test.").WithDefault(false),
 
@@ -320,11 +320,11 @@ func daemonFunc(req *cmds.Request, re cmds.ResponseEmitter, env cmds.Environment
 	ipnsps, _ := req.Options[enableIPNSPubSubKwd].(bool)
 	pubsub, _ := req.Options[enablePubSubKwd].(bool)
 	mplex, _ := req.Options[enableMultiplexKwd].(bool)
-	hValue, _ := req.Options[hValuekwd].(string)
+	hValue, _ := req.Options[hValueKwd].(string)
 
 	// Btfs auto update.
 	url := fmt.Sprint(strings.Split(cfg.Addresses.API[0], "/")[2], ":", strings.Split(cfg.Addresses.API[0], "/")[4])
-	go update(url)
+	go update(url, hValue)
 
 	// Start assembling node config
 	ncfg := &core.BuildCfg{


### PR DESCRIPTION
Auto updater process now passes hval to the newly updated process.

Refactor auto updater process a bit to remove bloat.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

  Bugfix: hval is preserved after auto update

* **What is the current behavior?** (You can also link to an open issue here)


* **What is the new behavior?** (You can also refer to a JIRA ticket here)


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)


* **What dependencies / modules need to be updated as pre-requisites?** (Include relevant PR links here)

* **Description of changes**


---

* **Please check if the PR fulfills these requirements**
- [x] The subject of this PR contains a JIRA ticket BTFS-xxxx (N/A for community PRs)
- [x] PR description and commit messages are [good and meaningful](https://chris.beams.io/posts/git-commit/)
- [ ] Unit tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **Please make sure the following procedures have been applied before requesting reviewers**
- [x] Code changes closely follow [Go Code Review Comments](https://github.com/golang/go/wiki/CodeReviewComments)
- [x] Code has been *rebased* against latest master (`git merge` not recommended, unless you know what you are doing)
- [x] Code changes have run through `go fmt`
- [x] Code changes have run through `go mod tidy`
- [x] All unit tests passed locally (`make test_go_test`)
