### PR TITLE
BTFS-1249 remove wget of config yaml file since in tarball now

### DIFF
--- a/sync_binaries.sh
+++ b/sync_binaries.sh
@@ -28,11 +28,9 @@ for OS in ${OS_VALUE[@]}; do
     for ARCH in ${ARCH_VALUE[@]}; do
         echo "=== Performing dload for "$OS" "$ARCH" ==="
         cd "$OS"/"$ARCH"
-        pwd
         wget -q distributions.btfs.io/"$S3Location"/"$OS"/"$ARCH"/btfs-"$OS"-"$ARCH".tar.gz 
         gunzip btfs-"$OS"-"$ARCH".tar.gz 
         tar -xf btfs-"$OS"-"$ARCH".tar
-        wget -q distributions.btfs.io/"$S3Location"/"$OS"/"$ARCH"/config_"$OS"_"$ARCH".yaml 
         wget -q distributions.btfs.io/"$S3Location"/"$OS"/"$ARCH"/update-"$OS"-"$ARCH".tar.gz
         tar -xf update-"$OS"-"$ARCH".tar.gz
         rm update-"$OS"-"$ARCH".tar.gz
@@ -45,10 +43,8 @@ done
 for ARCH in ${ARCH_VALUE[@]}; do
     echo "=== Performing dload for windows "$ARCH" ==="
     cd windows/"$ARCH"
-    pwd
-    wget -q distributions.btfs.io/"$S3Location"/windows/"$ARCH"/btfs-windows-"$ARCH".exe.zip
-    unzip -q btfs-windows-"$ARCH".exe.zip
-    wget -q distributions.btfs.io/"$S3Location"/windows/"$ARCH"/config_windows_"$ARCH".yaml
+    wget -q distributions.btfs.io/"$S3Location"/windows/"$ARCH"/btfs-windows-"$ARCH".zip
+    unzip -q btfs-windows-"$ARCH".zip
     wget -q distributions.btfs.io/"$S3Location"/windows/"$ARCH"/update-windows-"$ARCH".exe.zip
     unzip -q update-windows-"$ARCH".exe.zip
     rm update-windows-"$ARCH".exe.zip


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix

* **What is the current behavior?** (You can also link to an open issue here)
https://tronnetwork.atlassian.net/browse/BTFS-1249

* **What is the new behavior?** (You can also refer to a JIRA ticket here)
we dont need to pull down the config yaml anymore since the tarball/zip has it already

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
no

* **What dependencies / modules need to be updated as pre-requisites?** (Include relevant PR links here)
no

* **Description of changes**
edit script file to not perform a wget of the config yaml files
