### PR TITLE
BTFS-1320: Support more hub sync and upload modes

### DIFF
--- a/core/commands/storage/hosts_test.go
+++ b/core/commands/storage/hosts_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	unixtest "github.com/TRON-US/go-btfs/core/coreunix/test"
-	"github.com/TRON-US/go-btfs/core/hub"
 	"github.com/TRON-US/go-btfs/repo"
 
 	hubpb "github.com/tron-us/go-btfs-common/protos/hub"
@@ -22,8 +21,7 @@ func TestHostsSaveGet(t *testing.T) {
 	node := unixtest.HelpTestMockRepo(t, nil)
 
 	// test all possible modes
-	for _, mode := range []string{hub.HubModeAll, hub.HubModeScore,
-		hub.HubModeGeo, hub.HubModeRep, hub.HubModePrice, hub.HubModeSpeed} {
+	for _, mode := range hubpb.HostsReq_Mode_name {
 		var nodes []*hubpb.Host
 		for i := 0; i < 100; i++ {
 			ni := &hubpb.Host{NodeId: fmt.Sprintf("%s:node:%d", mode, i)}

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/TRON-US/go-btfs-api v0.1.0
 	github.com/TRON-US/go-btfs-chunker v0.2.7
 	github.com/TRON-US/go-btfs-cmds v0.1.5
-	github.com/TRON-US/go-btfs-config v0.3.0
+	github.com/TRON-US/go-btfs-config v0.3.1
 	github.com/TRON-US/go-btfs-files v0.1.3
 	github.com/TRON-US/go-eccrypto v0.0.1
 	github.com/TRON-US/go-mfs v0.2.2
@@ -121,7 +121,7 @@ require (
 	github.com/shirou/gopsutil v2.19.11+incompatible
 	github.com/stretchr/testify v1.4.0
 	github.com/syndtr/goleveldb v1.0.0
-	github.com/tron-us/go-btfs-common v0.2.6
+	github.com/tron-us/go-btfs-common v0.2.8
 	github.com/tyler-smith/go-bip32 v0.0.0-20170922074101-2c9cfd177564
 	github.com/tyler-smith/go-bip39 v1.0.0
 	github.com/whyrusleeping/base32 v0.0.0-20170828182744-c30ac30633cc

--- a/go.sum
+++ b/go.sum
@@ -33,8 +33,8 @@ github.com/TRON-US/go-btfs-chunker v0.2.7 h1:eLIZjETFbCsQ2lY9gw97x8MHZJkfOUfsZ05
 github.com/TRON-US/go-btfs-chunker v0.2.7/go.mod h1:Wj0oyybAWtu5lpcAc90QQ3bhJ14JRXD50PqxP25wmnI=
 github.com/TRON-US/go-btfs-cmds v0.1.5 h1:AbnAPBAFxe67MPChbwFPJbyKY1Vm3lXybGDNQ4NUTno=
 github.com/TRON-US/go-btfs-cmds v0.1.5/go.mod h1:rtki4vmPzq7qmjdzThJELFpSpxTiORoXreHlExdI6eg=
-github.com/TRON-US/go-btfs-config v0.3.0 h1:zokaxIy4yUDN8MbFN/RonV3hAbdFibQK0Ia8xNEG1MQ=
-github.com/TRON-US/go-btfs-config v0.3.0/go.mod h1:SdSLMMxOxqLYvMI0eJItYH7mWkG22EX5WaGyUwOq3fU=
+github.com/TRON-US/go-btfs-config v0.3.1 h1:Zh8jwQYd2+G+wvZeU6G2a7IzJr9JtE1Cbk0KtL8iXf8=
+github.com/TRON-US/go-btfs-config v0.3.1/go.mod h1:8OX+nFNHkApAFYR2c51DcPRyKpsCQTaemTJFh71dRwA=
 github.com/TRON-US/go-btfs-files v0.1.1/go.mod h1:tD2vOKLcLCDNMn9rrA27n2VbNpHdKewGzEguIFY+EJ0=
 github.com/TRON-US/go-btfs-files v0.1.3 h1:yM+PQbQDoUjy10colCqBoKkC1ii8WKf995zAlXnyU1U=
 github.com/TRON-US/go-btfs-files v0.1.3/go.mod h1:I8LeoFulha712BW03zGgmDdNwa0qbAPwfMIglzw0fnE=
@@ -822,8 +822,8 @@ github.com/texttheater/golang-levenshtein v0.0.0-20180516184445-d188e65d659e/go.
 github.com/timakin/bodyclose v0.0.0-20190930140734-f7f2e9bca95e h1:RumXZ56IrCj4CL+g1b9OL/oH0QnsF976bC8xQFYUD5Q=
 github.com/timakin/bodyclose v0.0.0-20190930140734-f7f2e9bca95e/go.mod h1:Qimiffbc6q9tBWlVV6x0P9sat/ao1xEkREYPPj9hphk=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
-github.com/tron-us/go-btfs-common v0.2.6 h1:enN2kqGCjTrWdfkn2p+YRdGRjd5w+IEb/t396HPapzg=
-github.com/tron-us/go-btfs-common v0.2.6/go.mod h1:9ND33JahGMg52sCC2/gO5DakLsd1Pg2lVe2CihW7lBE=
+github.com/tron-us/go-btfs-common v0.2.8 h1:a/FmQpZIvSjg8fVE81yRVGxGm7WZWpopAK5pWo4N+cI=
+github.com/tron-us/go-btfs-common v0.2.8/go.mod h1:9ND33JahGMg52sCC2/gO5DakLsd1Pg2lVe2CihW7lBE=
 github.com/tron-us/go-common/v2 v2.0.5 h1:LiGEmOd0FVVRisFyg3AJWDWMXlM537M3JZ+gh75sBlw=
 github.com/tron-us/go-common/v2 v2.0.5/go.mod h1:GiKX9noBLHotkZAU+7ET4h7N0DYWnm3OcGHOFJg1Q68=
 github.com/tron-us/protobuf v1.3.4 h1:oqokl6jMAfe1fb/B6t1UMllbw/KtfdJcCn8plxPkHM8=


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
  Support modes from new hub proto definitions, notably, the testnet mode to download test-specific nodes information to datastore.

* **What is the current behavior?** (You can also link to an open issue here)


* **What is the new behavior?** (You can also refer to a JIRA ticket here)


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)


* **What dependencies / modules need to be updated as pre-requisites?** (Include relevant PR links here)

* **Description of changes**


---

* **Please check if the PR fulfills these requirements**
- [x] The subject of this PR contains a JIRA ticket BTFS-xxxx (N/A for community PRs)
- [x] PR description and commit messages are [good and meaningful](https://chris.beams.io/posts/git-commit/)
- [x] Unit tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **Please make sure the following procedures have been applied before requesting reviewers**
- [x] Code changes closely follow [Go Code Review Comments](https://github.com/golang/go/wiki/CodeReviewComments)
- [x] Code has been *rebased* against latest master (`git merge` not recommended, unless you know what you are doing)
- [x] Code changes have run through `go fmt`
- [x] Code changes have run through `go mod tidy`
- [x] All unit tests passed locally (`make test_go_test`)
