### PR TITLE
BTFS-654: Do not allow btfs pin rm and btfs rm if file has not expired

### DIFF
--- a/core/commands/pin.go
+++ b/core/commands/pin.go
@@ -47,9 +47,10 @@ type AddPinOutput struct {
 }
 
 const (
-	pinRecursiveOptionName  = "recursive"
-	pinProgressOptionName   = "progress"
-	durationCountOptionName = "durationCount"
+	pinRecursiveOptionName     = "recursive"
+	pinForceOptionName         = "force"
+	pinProgressOptionName      = "progress"
+	pinDurationCountOptionName = "duration-count"
 
 	defaultDurationCount = 0
 )
@@ -66,7 +67,7 @@ var addPinCmd = &cmds.Command{
 	Options: []cmds.Option{
 		cmds.BoolOption(pinRecursiveOptionName, "r", "Recursively pin the object linked to by the specified object(s).").WithDefault(true),
 		cmds.BoolOption(pinProgressOptionName, "Show progress"),
-		cmds.IntOption(durationCountOptionName, "d", "Duration for which the object is pinned in days. It is unpinned after the duration.").WithDefault(defaultDurationCount),
+		cmds.IntOption(pinDurationCountOptionName, "d", "Duration for which the object is pinned in days. It is unpinned after the duration.").WithDefault(defaultDurationCount),
 	},
 	Type: AddPinOutput{},
 	Run: func(req *cmds.Request, res cmds.ResponseEmitter, env cmds.Environment) error {
@@ -78,7 +79,7 @@ var addPinCmd = &cmds.Command{
 		// set options
 		recursive, _ := req.Options[pinRecursiveOptionName].(bool)
 		showProgress, _ := req.Options[pinProgressOptionName].(bool)
-		duration := req.Options[durationCountOptionName].(int)
+		duration := req.Options[pinDurationCountOptionName].(int)
 
 		if err := req.ParseBodyArgs(); err != nil {
 			return err
@@ -215,6 +216,7 @@ collected if needed. (By default, recursively. Use -r=false for direct pins.)
 	},
 	Options: []cmds.Option{
 		cmds.BoolOption(pinRecursiveOptionName, "r", "Recursively unpin the object linked to by the specified object(s).").WithDefault(true),
+		cmds.BoolOption(pinForceOptionName, "f", "Forcibly unpin the object, even if there are constraints (such as host-stored file).").WithDefault(false),
 	},
 	Type: PinOutput{},
 	Run: func(req *cmds.Request, res cmds.ResponseEmitter, env cmds.Environment) error {
@@ -232,6 +234,8 @@ collected if needed. (By default, recursively. Use -r=false for direct pins.)
 
 		// set recursive flag
 		recursive, _ := req.Options[pinRecursiveOptionName].(bool)
+		// set force flag
+		force, _ := req.Options[pinForceOptionName].(bool)
 
 		if err := req.ParseBodyArgs(); err != nil {
 			return err
@@ -252,7 +256,8 @@ collected if needed. (By default, recursively. Use -r=false for direct pins.)
 
 			id := enc.Encode(rp.Cid())
 			pins = append(pins, id)
-			if err := api.Pin().Rm(req.Context, rp, options.Pin.RmRecursive(recursive)); err != nil {
+			if err := api.Pin().Rm(req.Context, rp,
+				options.Pin.RmRecursive(recursive), options.Pin.RmForce(force)); err != nil {
 				return err
 			}
 		}

--- a/core/commands/pin.go
+++ b/core/commands/pin.go
@@ -47,10 +47,10 @@ type AddPinOutput struct {
 }
 
 const (
-	pinRecursiveOptionName     = "recursive"
-	pinForceOptionName         = "force"
-	pinProgressOptionName      = "progress"
-	pinDurationCountOptionName = "duration-count"
+	pinRecursiveOptionName        = "recursive"
+	pinForceOptionName            = "force"
+	pinProgressOptionName         = "progress"
+	pinAddDurationCountOptionName = "duration-count"
 
 	defaultDurationCount = 0
 )
@@ -67,7 +67,7 @@ var addPinCmd = &cmds.Command{
 	Options: []cmds.Option{
 		cmds.BoolOption(pinRecursiveOptionName, "r", "Recursively pin the object linked to by the specified object(s).").WithDefault(true),
 		cmds.BoolOption(pinProgressOptionName, "Show progress"),
-		cmds.IntOption(pinDurationCountOptionName, "d", "Duration for which the object is pinned in days. It is unpinned after the duration.").WithDefault(defaultDurationCount),
+		cmds.IntOption(pinAddDurationCountOptionName, "d", "Duration for which the object is pinned in days. It is unpinned after the duration.").WithDefault(defaultDurationCount),
 	},
 	Type: AddPinOutput{},
 	Run: func(req *cmds.Request, res cmds.ResponseEmitter, env cmds.Environment) error {
@@ -79,7 +79,7 @@ var addPinCmd = &cmds.Command{
 		// set options
 		recursive, _ := req.Options[pinRecursiveOptionName].(bool)
 		showProgress, _ := req.Options[pinProgressOptionName].(bool)
-		duration := req.Options[pinDurationCountOptionName].(int)
+		duration := req.Options[pinAddDurationCountOptionName].(int)
 
 		if err := req.ParseBodyArgs(); err != nil {
 			return err

--- a/core/commands/rm.go
+++ b/core/commands/rm.go
@@ -13,6 +13,10 @@ import (
 	ipld "github.com/ipfs/go-ipld-format"
 )
 
+const (
+	rmForceOptionName = "force"
+)
+
 var RmCmd = &cmds.Command{
 	Helptext: cmds.HelpText{
 		Tagline:          "Remove files or directories from a local btfs node.",
@@ -21,6 +25,9 @@ var RmCmd = &cmds.Command{
 
 	Arguments: []cmds.Argument{
 		cmds.StringArg("hash", true, true, "The hash(es) of the file(s)/directory(s) to be removed from the local btfs node.").EnableStdin(),
+	},
+	Options: []cmds.Option{
+		cmds.BoolOption(rmForceOptionName, "f", "Forcibly remove the object, even if there are constraints (such as host-stored file).").WithDefault(false),
 	},
 	Run: func(req *cmds.Request, res cmds.ResponseEmitter, env cmds.Environment) error {
 		n, err := cmdenv.GetNode(env)
@@ -31,6 +38,8 @@ var RmCmd = &cmds.Command{
 		if err != nil {
 			return err
 		}
+
+		force, _ := req.Options[rmForceOptionName].(bool)
 
 		var results stringList
 		for _, b := range req.Arguments {
@@ -47,7 +56,7 @@ var RmCmd = &cmds.Command{
 			}
 			if pinned {
 				// Since we are removing a file, we need to set recursive flag to true
-				err = api.Pin().Rm(req.Context, p, options.Pin.RmRecursive(true))
+				err = api.Pin().Rm(req.Context, p, options.Pin.RmRecursive(true), options.Pin.RmForce(force))
 				if err != nil {
 					return err
 				}

--- a/core/coreapi/pin.go
+++ b/core/coreapi/pin.go
@@ -82,7 +82,7 @@ func (api *PinAPI) Rm(ctx context.Context, p path.Path, opts ...caopts.PinRmOpti
 		return err
 	}
 	if exp && !settings.Force {
-		return fmt.Errorf("pin cannot be removed due to host-storage constraint: contract has not expired")
+		return fmt.Errorf("pin cannot be removed due to constraint: has not expired")
 	}
 
 	if err = api.pinning.Unpin(ctx, rp.Cid(), settings.Recursive); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/TRON-US/go-eccrypto v0.0.1
 	github.com/TRON-US/go-mfs v0.2.2
 	github.com/TRON-US/go-unixfs v0.5.3
-	github.com/TRON-US/interface-go-btfs-core v0.5.2
+	github.com/TRON-US/interface-go-btfs-core v0.5.3
 	github.com/Workiva/go-datastructures v1.0.50
 	github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf
 	github.com/blang/semver v3.5.1+incompatible
@@ -148,5 +148,3 @@ go 1.13
 replace github.com/ipfs/go-ipld-format => github.com/TRON-US/go-ipld-format v0.1.0
 
 replace github.com/ipfs/go-cid => github.com/TRON-US/go-cid v0.1.0
-
-replace github.com/TRON-US/interface-go-btfs-core => ../interface-go-btfs-core

--- a/go.mod
+++ b/go.mod
@@ -148,3 +148,5 @@ go 1.13
 replace github.com/ipfs/go-ipld-format => github.com/TRON-US/go-ipld-format v0.1.0
 
 replace github.com/ipfs/go-cid => github.com/TRON-US/go-cid v0.1.0
+
+replace github.com/TRON-US/interface-go-btfs-core => ../interface-go-btfs-core

--- a/go.sum
+++ b/go.sum
@@ -50,8 +50,8 @@ github.com/TRON-US/go-unixfs v0.4.4/go.mod h1:VBRlISp23R6JoJQ2t+O/VkIswnPo9PBVCh
 github.com/TRON-US/go-unixfs v0.4.12/go.mod h1:0Jv/z5OvpB4JpjJcUFB9turYohcoqjF/tmczQX9eeJ4=
 github.com/TRON-US/go-unixfs v0.5.3 h1:Dz5fBJ3tK1UiiKjUgpGdm+YAZIVg2X2GjwhOxCOvRnY=
 github.com/TRON-US/go-unixfs v0.5.3/go.mod h1:r89GEeiq8xVLDz0mxyaVjx9qCrOZrR3h5hJUTKAoeEE=
-github.com/TRON-US/interface-go-btfs-core v0.5.2 h1:iNqNTntjbPvI+5gZPh1z1QQY+FM19LPEeS4/24nZapQ=
-github.com/TRON-US/interface-go-btfs-core v0.5.2/go.mod h1:wZWJikVV3ShW7fClZP8/Gv8gYFg4ZowePkKBp0HY9Xc=
+github.com/TRON-US/interface-go-btfs-core v0.5.3 h1:4DNfkYct96IheqcQXCGJzMO2HJTt/IgeI5BtJXL7qzo=
+github.com/TRON-US/interface-go-btfs-core v0.5.3/go.mod h1:wZWJikVV3ShW7fClZP8/Gv8gYFg4ZowePkKBp0HY9Xc=
 github.com/Workiva/go-datastructures v1.0.50 h1:slDmfW6KCHcC7U+LP3DDBbm4fqTwZGn1beOFPfGaLvo=
 github.com/Workiva/go-datastructures v1.0.50/go.mod h1:Z+F2Rca0qCsVYDS8z7bAGm8f3UkzuWYS/oBZz5a7VVA=
 github.com/aead/siphash v1.0.1/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBAUSII=


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

  Feature

* **What is the current behavior?** (You can also link to an open issue here)

  Host stored files can be unpinned and removed easily

* **What is the new behavior?** (You can also refer to a JIRA ticket here)

  Must use --force to pin rm host stored file (unexpired file)

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)


* **What dependencies / modules need to be updated as pre-requisites?** (Include relevant PR links here)

* **Description of changes**


---

* **Please check if the PR fulfills these requirements**
- [x] The subject of this PR contains a JIRA ticket BTFS-xxxx (N/A for community PRs)
- [x] PR description and commit messages are [good and meaningful](https://chris.beams.io/posts/git-commit/)
- [ ] Unit tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **Please make sure the following procedures have been applied before requesting reviewers**
- [x] Code changes closely follow [Go Code Review Comments](https://github.com/golang/go/wiki/CodeReviewComments)
- [x] Code has been *rebased* against latest master (`git merge` not recommended, unless you know what you are doing)
- [x] Code changes have run through `go fmt`
- [x] Code changes have run through `go mod tidy`
- [x] All unit tests passed locally (`make test_go_test`)
