### PR TITLE
BTFS-1280 perform rm -f since files may not be present

### DIFF
--- a/package.sh
+++ b/package.sh
@@ -18,7 +18,7 @@ do
         if [[ ${goos} = "windows" ]]; then
             ext=".exe"
         fi
-        rm ../btfs-binary-releases/${goos}/${goarch}/*
+        rm -f ../btfs-binary-releases/${goos}/${goarch}/*
         GOOS=${goos} GOARCH=${goarch} make build
         GOOS=${goos} GOARCH=${goarch} go build -o update-${goos}-${goarch}${ext} autoupdate/main.go
         md5=`openssl md5 ./cmd/btfs/btfs | awk '{print $2}'`

--- a/sync_binaries.sh
+++ b/sync_binaries.sh
@@ -15,12 +15,12 @@ cd ../btfs-binary-releases
 
 #delete existing files
 echo "=== Deleting old files ==="
-rm -r ./darwin/386/*
-rm -r ./darwin/amd64/*
-rm -r ./linux/386/*
-rm -r ./linux/amd64/*
-rm -r ./windows/386/*
-rm -r ./windows/amd64/*
+rm -rf ./darwin/386/*
+rm -rf ./darwin/amd64/*
+rm -rf ./linux/386/*
+rm -rf ./linux/amd64/*
+rm -rf ./windows/386/*
+rm -rf ./windows/amd64/*
 echo "=== Completed deleting old files ==="
 
 #download files for darwin and linux


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix

* **What is the current behavior?** (You can also link to an open issue here)
package script reports error on rm if the binary-releases repo is not cloned

* **What is the new behavior?** (You can also refer to a JIRA ticket here)
ignore missing files with the -f flag for rm command

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
no

* **What dependencies / modules need to be updated as pre-requisites?** (Include relevant PR links here)
no dependencies
