### PR TITLE
BTFS-1447 bug fix, dash in version will not try to autoupdate

### DIFF
--- a/cmd/btfs/autoupdate.go
+++ b/cmd/btfs/autoupdate.go
@@ -410,7 +410,7 @@ func versionCompare(version1, version2 string) (int, error) {
 			return UPGRADE_FLAG_LATEST, nil
 		}
 	}
-	return 0, nil
+	return UPGRADE_FLAG_LATEST, nil
 }
 
 // Get current program execution path.

--- a/cmd/btfs/autoupdate.go
+++ b/cmd/btfs/autoupdate.go
@@ -167,13 +167,19 @@ func update(url, hval string) {
 		}
 
 		// Compare version.
-		flg, err := versionCompare(latestConfig.Version, version)
+		upgradeFlg, err := versionCompare(latestConfig.Version, version)
 		if err != nil {
 			log.Errorf("Version compare error, reasons: [%v]", err)
 			continue
 		}
 
-		if flg <= 0 {
+		if upgradeFlg == 0 {
+			fmt.Println("BTFS will not automatically update.")
+			sleepTimeSeconds = latestConfig.SleepTimeSeconds
+			continue
+		}
+
+		if upgradeFlg == -1 {
 			fmt.Println("BTFS is up-to-date.")
 			sleepTimeSeconds = latestConfig.SleepTimeSeconds
 			continue
@@ -361,6 +367,19 @@ func versionCompare(version1, version2 string) (int, error) {
 	if s2 == nil || len(s2) != 3 {
 		log.Error("String fo version2 has wrong format.")
 		return 0, errors.New("string fo version2 has wrong format")
+	}
+
+	// If the current config.yaml contains a dash in the last section
+	// then do not automatic update.
+	if strings.Contains(s2[2], "-") {
+		fmt.Println("BTFS config.yaml shows a dev version.")
+		return 0, nil
+	}
+	// If the newly downloaded config.yaml contains a dash in the last section
+	// then do not automatic update.
+	if strings.Contains(s1[2], "-") {
+		fmt.Println("BTFS upgrade config.yaml shows a dev version.")
+		return 0, nil
 	}
 
 	for i := 0; i < 3; i++ {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix

* **What is the current behavior?** (You can also link to an open issue here)
autoupdate will show an error message. see BTFS-1447

* **What is the new behavior?** (You can also refer to a JIRA ticket here)
the version strings in both config.yaml on disk and the newly downloaded config.yaml will be checked for a dash in the 3rd slice.  if there is a dash, the autoupdate will not run.  a message is shown when when a dash is found saying autoupdate will not run.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
no

* **What dependencies / modules need to be updated as pre-requisites?** (Include relevant PR links here)
none 

* **Tested with**
- old version string compared with downloaded config, autoupdate runs fine
- newer version string than downloaded config, message shown:
```
BTFS is up-to-date.
```
- version string contains a dash, message shown:
```
BTFS config.yaml shows a dev version.
BTFS will not automatically update.
```

---

* **Please check if the PR fulfills these requirements**
- [ ] The subject of this PR contains a JIRA ticket BTFS-xxxx (N/A for community PRs)
- [ ] PR description and commit messages are [good and meaningful](https://chris.beams.io/posts/git-commit/)
- [ ] Unit tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **Please make sure the following procedures have been applied before requesting reviewers**
- [ ] Code changes closely follow [Go Code Review Comments](https://github.com/golang/go/wiki/CodeReviewComments)
- [ ] Code has been *rebased* against latest master (`git merge` not recommended, unless you know what you are doing)
- [x] Code changes have run through `go fmt`
- [ ] Code changes have run through `go mod tidy`
- [ ] All unit tests passed locally (`make test_go_test`)
