### PR TITLE
BTFS-1508: btfs daemon can use swarm-port option to override swarm

### DIFF
--- a/cmd/btfs/init.go
+++ b/cmd/btfs/init.go
@@ -307,7 +307,7 @@ func addDefaultAssets(out io.Writer, repoRoot string) error {
 	err = buildCfg.AnnouncePublicIp()
 	if err != nil {
 		// don't quit here, user can manually add to config later
-		fmt.Fprintf(out, "announce public ip failed.\n")
+		fmt.Fprintf(out, "announce public ip failed: %v\n", err)
 	}
 
 	dkey, err := assets.SeedInitDocs(nd)

--- a/core/node/builder.go
+++ b/core/node/builder.go
@@ -122,17 +122,31 @@ func (cfg *BuildCfg) options(ctx context.Context) (fx.Option, *cfg.Config) {
 	), conf
 }
 
+// AnnouncePublicIp announces swarm address with default (direct) port
 func (bcfg *BuildCfg) AnnouncePublicIp() error {
 	conf, err := bcfg.Repo.Config()
 	if err != nil {
 		return err
 	}
 	address, err := cfg.ExternalIP()
-	if err == nil {
-		if !contains(conf.Addresses.Announce, address) {
-			conf.Addresses.Announce = append(conf.Addresses.Announce, address)
-			bcfg.Repo.SetConfig(conf)
-		}
+	if err == nil && !contains(conf.Addresses.Announce, address) {
+		conf.Addresses.Announce = append(conf.Addresses.Announce, address)
+		return bcfg.Repo.SetConfig(conf)
+	}
+	return err
+}
+
+// AnnouncePublicIpWithPort announces swarm address with external port and
+// performs internal port validation
+func (bcfg *BuildCfg) AnnouncePublicIpWithPort(extPort, intPort int) error {
+	conf, err := bcfg.Repo.Config()
+	if err != nil {
+		return err
+	}
+	address, err := cfg.ExternalIPWithPort(extPort, intPort, conf.Addresses.Swarm)
+	if err == nil && !contains(conf.Addresses.Announce, address) {
+		conf.Addresses.Announce = append(conf.Addresses.Announce, address)
+		return bcfg.Repo.SetConfig(conf)
 	}
 	return err
 }

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/TRON-US/go-btfs-api v0.1.0
 	github.com/TRON-US/go-btfs-chunker v0.2.7
 	github.com/TRON-US/go-btfs-cmds v0.1.5
-	github.com/TRON-US/go-btfs-config v0.4.1
+	github.com/TRON-US/go-btfs-config v0.4.2
 	github.com/TRON-US/go-btfs-files v0.1.3
 	github.com/TRON-US/go-eccrypto v0.0.1
 	github.com/TRON-US/go-mfs v0.2.2

--- a/go.sum
+++ b/go.sum
@@ -32,8 +32,8 @@ github.com/TRON-US/go-btfs-chunker v0.2.7 h1:eLIZjETFbCsQ2lY9gw97x8MHZJkfOUfsZ05
 github.com/TRON-US/go-btfs-chunker v0.2.7/go.mod h1:Wj0oyybAWtu5lpcAc90QQ3bhJ14JRXD50PqxP25wmnI=
 github.com/TRON-US/go-btfs-cmds v0.1.5 h1:AbnAPBAFxe67MPChbwFPJbyKY1Vm3lXybGDNQ4NUTno=
 github.com/TRON-US/go-btfs-cmds v0.1.5/go.mod h1:rtki4vmPzq7qmjdzThJELFpSpxTiORoXreHlExdI6eg=
-github.com/TRON-US/go-btfs-config v0.4.1 h1:Cj6DITP5Zd6TZvDUkmvKyaH/AKX4JSGtB57gKXZp70g=
-github.com/TRON-US/go-btfs-config v0.4.1/go.mod h1:045+FmBpTIWNy34ISzjtPaEf6afBq6wVQtviNmAnF5g=
+github.com/TRON-US/go-btfs-config v0.4.2 h1:woJnY+ba8UNbJXUu6VAElJJVeZzaR2NqtMvDKQoB3tA=
+github.com/TRON-US/go-btfs-config v0.4.2/go.mod h1:045+FmBpTIWNy34ISzjtPaEf6afBq6wVQtviNmAnF5g=
 github.com/TRON-US/go-btfs-files v0.1.1/go.mod h1:tD2vOKLcLCDNMn9rrA27n2VbNpHdKewGzEguIFY+EJ0=
 github.com/TRON-US/go-btfs-files v0.1.3 h1:yM+PQbQDoUjy10colCqBoKkC1ii8WKf995zAlXnyU1U=
 github.com/TRON-US/go-btfs-files v0.1.3/go.mod h1:I8LeoFulha712BW03zGgmDdNwa0qbAPwfMIglzw0fnE=


### PR DESCRIPTION
address for announce

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

  feature/fix

* **What is the current behavior?** (You can also link to an open issue here)


* **What is the new behavior?** (You can also refer to a JIRA ticket here)

  can override swarm address with external port

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)


* **What dependencies / modules need to be updated as pre-requisites?** (Include relevant PR links here)

  https://github.com/TRON-US/go-btfs-config/pull/26

* **Description of changes**


---

* **Please check if the PR fulfills these requirements**
- [x] The subject of this PR contains a JIRA ticket BTFS-xxxx (N/A for community PRs)
- [x] PR description and commit messages are [good and meaningful](https://chris.beams.io/posts/git-commit/)
- [ ] Unit tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **Please make sure the following procedures have been applied before requesting reviewers**
- [ ] Code changes closely follow [Go Code Review Comments](https://github.com/golang/go/wiki/CodeReviewComments)
- [ ] Code has been *rebased* against latest master (`git merge` not recommended, unless you know what you are doing)
- [ ] Code changes have run through `go fmt`
- [ ] Code changes have run through `go mod tidy`
- [ ] All unit tests passed locally (`make test_go_test`)
