### PR TITLE
BTFS-1441: Redirect /api/latest and /api/v0 to /api/v1

### DIFF
--- a/core/corehttp/commands.go
+++ b/core/corehttp/commands.go
@@ -38,6 +38,12 @@ cli arguments:
 // APIPath is the path at which the API is mounted.
 const APIPath = "/api/" + shell.API_VERSION
 
+// redirectPaths contain the paths to be redirectd to the current APIPath
+var redirectPaths = []string{
+	"/api/v0",
+	"/api/latest",
+}
+
 var defaultLocalhostOrigins = []string{
 	"http://127.0.0.1:<port>",
 	"https://127.0.0.1:<port>",
@@ -124,6 +130,7 @@ func commandsOption(cctx oldcmds.Context, command *cmds.Command) ServeOption {
 		cfg := cmdsHttp.NewServerConfig()
 		cfg.SetAllowedMethods("GET", "POST", "PUT")
 		cfg.APIPath = APIPath
+		cfg.RedirectPaths = redirectPaths
 		rcfg, err := n.Repo.Config()
 		if err != nil {
 			return nil, err
@@ -136,6 +143,9 @@ func commandsOption(cctx oldcmds.Context, command *cmds.Command) ServeOption {
 
 		cmdHandler := cmdsHttp.NewHandler(&cctx, command, cfg)
 		mux.Handle(APIPath+"/", cmdHandler)
+		for _, rp := range redirectPaths {
+			mux.Handle(rp+"/", cmdHandler)
+		}
 		return mux, nil
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/StackExchange/wmi v0.0.0-20181212234831-e0a55b97c705 // indirect
 	github.com/TRON-US/go-btfs-api v0.1.0
 	github.com/TRON-US/go-btfs-chunker v0.2.7
-	github.com/TRON-US/go-btfs-cmds v0.1.5
+	github.com/TRON-US/go-btfs-cmds v0.1.6
 	github.com/TRON-US/go-btfs-config v0.4.2
 	github.com/TRON-US/go-btfs-files v0.1.3
 	github.com/TRON-US/go-eccrypto v0.0.1

--- a/go.sum
+++ b/go.sum
@@ -30,8 +30,8 @@ github.com/TRON-US/go-btfs-chunker v0.2.4/go.mod h1:Wj0oyybAWtu5lpcAc90QQ3bhJ14J
 github.com/TRON-US/go-btfs-chunker v0.2.6/go.mod h1:Wj0oyybAWtu5lpcAc90QQ3bhJ14JRXD50PqxP25wmnI=
 github.com/TRON-US/go-btfs-chunker v0.2.7 h1:eLIZjETFbCsQ2lY9gw97x8MHZJkfOUfsZ05uxfKZF6Y=
 github.com/TRON-US/go-btfs-chunker v0.2.7/go.mod h1:Wj0oyybAWtu5lpcAc90QQ3bhJ14JRXD50PqxP25wmnI=
-github.com/TRON-US/go-btfs-cmds v0.1.5 h1:AbnAPBAFxe67MPChbwFPJbyKY1Vm3lXybGDNQ4NUTno=
-github.com/TRON-US/go-btfs-cmds v0.1.5/go.mod h1:rtki4vmPzq7qmjdzThJELFpSpxTiORoXreHlExdI6eg=
+github.com/TRON-US/go-btfs-cmds v0.1.6 h1:r1JCcAfWxGHpFxZpmlQN3NTEqbN9BRmX4ximfmBh2ok=
+github.com/TRON-US/go-btfs-cmds v0.1.6/go.mod h1:rtki4vmPzq7qmjdzThJELFpSpxTiORoXreHlExdI6eg=
 github.com/TRON-US/go-btfs-config v0.4.2 h1:woJnY+ba8UNbJXUu6VAElJJVeZzaR2NqtMvDKQoB3tA=
 github.com/TRON-US/go-btfs-config v0.4.2/go.mod h1:045+FmBpTIWNy34ISzjtPaEf6afBq6wVQtviNmAnF5g=
 github.com/TRON-US/go-btfs-files v0.1.1/go.mod h1:tD2vOKLcLCDNMn9rrA27n2VbNpHdKewGzEguIFY+EJ0=


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

  feature

* **What is the current behavior?** (You can also link to an open issue here)


* **What is the new behavior?** (You can also refer to a JIRA ticket here)

  redirecting /api/latest and legacy /api/v0 to /api/v1

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

  https://github.com/TRON-US/go-btfs-cmds/pull/10

* **What dependencies / modules need to be updated as pre-requisites?** (Include relevant PR links here)

* **Description of changes**


---

* **Please check if the PR fulfills these requirements**
- [ ] The subject of this PR contains a JIRA ticket BTFS-xxxx (N/A for community PRs)
- [ ] PR description and commit messages are [good and meaningful](https://chris.beams.io/posts/git-commit/)
- [ ] Unit tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **Please make sure the following procedures have been applied before requesting reviewers**
- [ ] Code changes closely follow [Go Code Review Comments](https://github.com/golang/go/wiki/CodeReviewComments)
- [ ] Code has been *rebased* against latest master (`git merge` not recommended, unless you know what you are doing)
- [ ] Code changes have run through `go fmt`
- [ ] Code changes have run through `go mod tidy`
- [ ] All unit tests passed locally (`make test_go_test`)
