### PR TITLE
BTFS-1523: btfs rm should work for files with identical data blocks

### DIFF
--- a/core/commands/rm.go
+++ b/core/commands/rm.go
@@ -64,7 +64,7 @@ var RmCmd = &cmds.Command{
 			}
 
 			// Rm all child links
-			err = rmAllDags(req.Context, api, node, &results)
+			err = rmAllDags(req.Context, api, node, &results, map[string]bool{})
 			if err != nil {
 				return err
 			}
@@ -78,14 +78,20 @@ var RmCmd = &cmds.Command{
 	},
 }
 
-func rmAllDags(ctx context.Context, api coreiface.CoreAPI, node ipld.Node, res *stringList) error {
+func rmAllDags(ctx context.Context, api coreiface.CoreAPI, node ipld.Node, res *stringList,
+	removed map[string]bool) error {
 	for _, nl := range node.Links() {
+		// Skipped just removed nodes
+		if _, ok := removed[nl.Cid.String()]; ok {
+			continue
+		}
 		// Resolve, recurse, then finally remove
 		rn, err := api.ResolveNode(ctx, path.IpfsPath(nl.Cid))
 		if err != nil {
+			res.Strings = append(res.Strings, fmt.Sprintf("Error resolving object %s", nl.Cid))
 			return err
 		}
-		if err := rmAllDags(ctx, api, rn, res); err != nil {
+		if err := rmAllDags(ctx, api, rn, res, removed); err != nil {
 			return err
 		}
 	}
@@ -95,6 +101,7 @@ func rmAllDags(ctx context.Context, api coreiface.CoreAPI, node ipld.Node, res *
 		return err
 	} else {
 		res.Strings = append(res.Strings, fmt.Sprintf("Removed %s", ncid))
+		removed[ncid.String()] = true
 	}
 	return nil
 }


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

  bugfix

* **What is the current behavior?** (You can also link to an open issue here)

  btfs rm does not work for files (small) with identical data blocks

* **What is the new behavior?** (You can also refer to a JIRA ticket here)

  fixed

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)


* **What dependencies / modules need to be updated as pre-requisites?** (Include relevant PR links here)

* **Description of changes**


---

* **Please check if the PR fulfills these requirements**
- [x] The subject of this PR contains a JIRA ticket BTFS-xxxx (N/A for community PRs)
- [x] PR description and commit messages are [good and meaningful](https://chris.beams.io/posts/git-commit/)
- [ ] Unit tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **Please make sure the following procedures have been applied before requesting reviewers**
- [x] Code changes closely follow [Go Code Review Comments](https://github.com/golang/go/wiki/CodeReviewComments)
- [x] Code has been *rebased* against latest master (`git merge` not recommended, unless you know what you are doing)
- [x] Code changes have run through `go fmt`
- [x] Code changes have run through `go mod tidy`
- [x] All unit tests passed locally (`make test_go_test`)
