### PR TITLE
BTFS-1536 fix autoupdate to not use .exe.zip file extensions anymore

### DIFF
--- a/cmd/btfs/autoupdate.go
+++ b/cmd/btfs/autoupdate.go
@@ -87,7 +87,7 @@ func update(url, hval string) {
 		if runtime.GOOS == "windows" {
 			ext = ".exe"
 			sep = "\\"
-			compressedExt = ".exe.zip"
+			compressedExt = ".zip"
 		}
 
 		latestConfigFile = fmt.Sprintf(LatestConfigFile, runtime.GOOS, runtime.GOARCH)

--- a/sync_binaries.sh
+++ b/sync_binaries.sh
@@ -45,9 +45,9 @@ for ARCH in ${ARCH_VALUE[@]}; do
     cd windows/"$ARCH"
     wget -q distributions.btfs.io/"$S3Location"/windows/"$ARCH"/btfs-windows-"$ARCH".zip
     unzip -q btfs-windows-"$ARCH".zip
-    wget -q distributions.btfs.io/"$S3Location"/windows/"$ARCH"/update-windows-"$ARCH".exe.zip
-    unzip -q update-windows-"$ARCH".exe.zip
-    rm update-windows-"$ARCH".exe.zip
+    wget -q distributions.btfs.io/"$S3Location"/windows/"$ARCH"/update-windows-"$ARCH".zip
+    unzip -q update-windows-"$ARCH".zip
+    rm update-windows-"$ARCH".zip
 
     cd ../..
 done


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
the windows zip files will be named .zip instead of exe.zip

* **What is the current behavior?** (You can also link to an open issue here)
autoupdate expects go-btfs binaries for windows to be named exe.zip which is not conventional

* **What is the new behavior?** (You can also refer to a JIRA ticket here)
the windows zip files will be named .zip instead of exe.zip


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
no.  we will still build and upload the exe.zip and plain zip files in the jenkins jobs.  eventually we will stop uploading the exe.zip files once everyone has upgraded post 1.0.2 beta 3.

* **What dependencies / modules need to be updated as pre-requisites?** (Include relevant PR links here)
none 

* **Description of changes**


---

* **Please check if the PR fulfills these requirements**
- [x] The subject of this PR contains a JIRA ticket BTFS-xxxx (N/A for community PRs)
- [x] PR description and commit messages are [good and meaningful](https://chris.beams.io/posts/git-commit/)
- [ ] Unit tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **Please make sure the following procedures have been applied before requesting reviewers**
- [ ] Code changes closely follow [Go Code Review Comments](https://github.com/golang/go/wiki/CodeReviewComments)
- [ ] Code has been *rebased* against latest master (`git merge` not recommended, unless you know what you are doing)
- [x] Code changes have run through `go fmt`
- [x] Code changes have run through `go mod tidy`
- [x] All unit tests passed locally (`make test_go_test`)
