### PR TITLE
BTFS 1850 - Update Dockerfile golang version to 1.14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13-stretch
+FROM golang:1.14-stretch
 MAINTAINER TRON-US <support@tron.network>
 
 ENV SRC_DIR /go-btfs

--- a/Dockerfile.testing
+++ b/Dockerfile.testing
@@ -1,4 +1,4 @@
-FROM golang:1.13-stretch
+FROM golang:1.14-stretch
 MAINTAINER TRON-US <support@tron.network>
 # Dockerfile.testing will build an image that contains the go-btfs source and binary.
 # It is quite large.  Its primary use case is to run the unit tests and test/sharness tests.

--- a/Dockerfile.unit_testing
+++ b/Dockerfile.unit_testing
@@ -1,4 +1,4 @@
-FROM golang:1.13-stretch
+FROM golang:1.14-stretch
 MAINTAINER TRON-US <support@tron.network>
 # Dockerfile.unit_testing will build an image to run the go unit tests.
 # Use the regular Dockerfile to run a btfs daemon instead

--- a/README.md
+++ b/README.md
@@ -81,8 +81,8 @@ $ make install
 go: downloading github.com/tron-us/go-btfs-common v0.2.28
 go: extracting github.com/tron-us/go-btfs-common v0.2.28
 go: finding github.com/tron-us/go-btfs-common v0.2.28
-go version go1.13.1 darwin/amd64
-bin/check_go_version 1.13
+go version go1.14.1 darwin/amd64
+bin/check_go_version 1.14
 bash patching.sh
 go install  "-asmflags=all='-trimpath='" "-gcflags=all='-trimpath='" -ldflags="-X "github.com/TRON-US/go-btfs".CurrentCommit=e4848946d" ./cmd/btfs
 ```
@@ -99,10 +99,10 @@ $ sudo yum install patch   // Required for building from source
 $ sudo yum install gcc     // Required for building from source
 ```
 
-Building BTFS from source requires Go 1.13 or higher. To install from the terminal:
+Building BTFS from source requires Go 1.14 or higher. To install from the terminal:
 ```
 $ cd /tmp
-$ GO_PACKAGE=go1.13.linux-amd64.tar.gz
+$ GO_PACKAGE=go1.14.linux-amd64.tar.gz
 $ wget https://golang.org/dl/$GO_PACKAGE
 $ sudo tar -xvf $GO_PACKAGE
 $ sudo mv go /usr/local
@@ -117,7 +117,7 @@ $ export PATH=$PATH:$GOPATH/bin
 $ export GO111MODULE=on
 ```
 
-Verify the Go version is 1.13 or higher:
+Verify the Go version is 1.14 or higher:
 ```
 $ go version
 ```
@@ -141,7 +141,7 @@ $ docker image build -t btfs_docker .   // Builds the docker image and tags "btf
 A successful build should have an output like:
 ```
 Sending build context to Docker daemon  2.789MB
-Step 1/37 : FROM golang:1.13-stretch
+Step 1/37 : FROM golang:1.14-stretch
  ---> 4fe257ac564c
 Step 2/37 : MAINTAINER TRON-US <support@tron.network>
  ---> Using cache

--- a/go.mod
+++ b/go.mod
@@ -149,7 +149,7 @@ require (
 	launchpad.net/gocheck v0.0.0-20140225173054-000000000087 // indirect
 )
 
-go 1.13
+go 1.14
 
 replace github.com/ipfs/go-ipld-format => github.com/TRON-US/go-ipld-format v0.1.0
 

--- a/mk/golang.mk
+++ b/mk/golang.mk
@@ -1,5 +1,5 @@
 # golang utilities
-GO_MIN_VERSION = 1.13
+GO_MIN_VERSION = 1.14
 export GO111MODULE=on
 
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
To avoid the windows ddl preloading issue, upgrade docker go version to 1.14. Also change README and some reference place which defined go version.

* **What is the current behavior?** (You can also link to an open issue here)
Current docker go version is 1.13 which may cause ddl preloading issue. 

* **What is the new behavior?** (You can also refer to a JIRA ticket here)
Jira ticket number BTFS-1850.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **What dependencies / modules need to be updated as pre-requisites?** (Include relevant PR links here)
No

* **Description of changes**
1. Change Dockerfiles from golang:1.13-stretch to golang:1.14-stretch.
2. Update README, golang.mk and go.mod go version.


---

* **Please check if the PR fulfills these requirements**
- [ ] The subject of this PR contains a JIRA ticket BTFS-xxxx (N/A for community PRs)
- [ ] PR description and commit messages are [good and meaningful](https://chris.beams.io/posts/git-commit/)
- [ ] Unit tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **Please make sure the following procedures have been applied before requesting reviewers**
- [ ] Code changes closely follow [Go Code Review Comments](https://github.com/golang/go/wiki/CodeReviewComments)
- [ ] Code has been *rebased* against latest master (`git merge` not recommended, unless you know what you are doing)
- [ ] Code changes have run through `go fmt`
- [ ] Code changes have run through `go mod tidy`
- [ ] All unit tests passed locally (`make test_go_test`)
