### PR TITLE
Improve System version output

### DIFF
--- a/core/commands/version.go
+++ b/core/commands/version.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"runtime"
 	"runtime/debug"
+	"syscall"
 
 	version "github.com/TRON-US/go-btfs"
 	fsrepo "github.com/TRON-US/go-btfs/repo/fsrepo"
@@ -28,6 +29,30 @@ const (
 	versionAllOptionName    = "all"
 )
 
+func convertInt8ToStr(array []int8) string {
+	var str string
+	for _, v := range array {
+		str += string(int(v))
+	}
+	return str
+}
+
+func getSystemVersionString() string {
+	var systemVersion = runtime.GOARCH + "/" + runtime.GOOS
+	var uname syscall.Utsname
+
+	// get system version from uname when available
+	if err := syscall.Uname(&uname); err == nil {
+		systemVersion = fmt.Sprintf("%s %s %s",
+			convertInt8ToStr(uname.Sysname[:]),
+			convertInt8ToStr(uname.Release[:]),
+			convertInt8ToStr(uname.Version[:]))
+	}
+
+	return systemVersion
+}
+
+
 var VersionCmd = &cmds.Command{
 	Helptext: cmds.HelpText{
 		Tagline:          "Show btfs version information.",
@@ -48,7 +73,7 @@ var VersionCmd = &cmds.Command{
 			Version: version.CurrentVersionNumber,
 			Commit:  version.CurrentCommit,
 			Repo:    fmt.Sprint(fsrepo.RepoVersion),
-			System:  runtime.GOARCH + "/" + runtime.GOOS, //TODO: Precise version here
+			System:  getSystemVersionString(),
 			Golang:  runtime.Version(),
 		})
 	},


### PR DESCRIPTION
get and output SystemVersion from uname when available

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Improvement

* **What is the current behavior?** (You can also link to an open issue here)

```
$ btfs version --all
go-btfs version: 1.2.0-dev-4693f6e57
Repo version: 7
System version: amd64/linux
Golang version: go1.14.2
```

* **What is the new behavior?** (You can also refer to a JIRA ticket here)

```
$ btfs version --all
go-btfs version: 1.2.0-dev-59c9b4a71
Repo version: 7
System version: Linux 5.6.11-arch1-1 #1 SMP PREEMPT Wed, 06 May 2020 17:32:37 +0000
Golang version: go1.14.2
```

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **What dependencies / modules need to be updated as pre-requisites?** (Include relevant PR links here)

None

* **Description of changes**
Improve System version output

Current:
```
System version: amd64/linux
```

New:
```
System version: Linux 5.6.11-arch1-1 #1 SMP PREEMPT Wed, 06 May 2020 17:32:37 +0000
```
---

* **Please check if the PR fulfills these requirements**
- [ ] The subject of this PR contains a JIRA ticket BTFS-xxxx (N/A for community PRs)
- [x] PR description and commit messages are [good and meaningful](https://chris.beams.io/posts/git-commit/)
- [ ] Unit tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **Please make sure the following procedures have been applied before requesting reviewers**
- [x] Code changes closely follow [Go Code Review Comments](https://github.com/golang/go/wiki/CodeReviewComments)
- [x] Code has been *rebased* against latest master (`git merge` not recommended, unless you know what you are doing)
- [x] Code changes have run through `go fmt`
- [x] Code changes have run through `go mod tidy`
- [x] All unit tests passed locally (`make test_go_test`)
