### PR TITLE
BTFS-2308: bug: btfs node crashes with too many files / cpu info crash

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -116,7 +116,7 @@ require (
 	github.com/orcaman/concurrent-map v0.0.0-20190826125027-8c72a8bb44f6
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.5.1
-	github.com/shirou/gopsutil v2.20.5+incompatible
+	github.com/shirou/gopsutil v2.20.7+incompatible
 	github.com/status-im/keycard-go v0.0.0-20190316090335-8537d3370df4
 	github.com/stretchr/testify v1.6.1
 	github.com/syndtr/goleveldb v1.0.1-0.20190923125748-758128399b1d

--- a/go.sum
+++ b/go.sum
@@ -949,6 +949,8 @@ github.com/segmentio/encoding v0.1.10/go.mod h1:RWhr02uzMB9gQC1x+MfYxedtmBibb9cZ
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/shirou/gopsutil v2.20.5+incompatible h1:tYH07UPoQt0OCQdgWWMgYHy3/a9bcxNpBIysykNIP7I=
 github.com/shirou/gopsutil v2.20.5+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
+github.com/shirou/gopsutil v2.20.7+incompatible h1:Ymv4OD12d6zm+2yONe39VSmp2XooJe8za7ngOLW/o/w=
+github.com/shirou/gopsutil v2.20.7+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
 github.com/shurcooL/component v0.0.0-20170202220835-f88ec8f54cc4/go.mod h1:XhFIlyj5a1fBNx5aJTbKoIq0mNaPvOagO+HjB3EtxrY=
 github.com/shurcooL/events v0.0.0-20181021180414-410e4ca65f48/go.mod h1:5u70Mqkb5O5cxEA8nxTsgrgLehJeAw6Oc4Ab1c/P1HM=
 github.com/shurcooL/github_flavored_markdown v0.0.0-20181002035957-2122de532470/go.mod h1:2dOwnU2uBioM+SGy2aZoq1f/Sd1l9OkAeAUvjSyvgU0=

--- a/spin/analytics.go
+++ b/spin/analytics.go
@@ -179,7 +179,9 @@ func (dc *dcWrap) update(node *core.IpfsNode) []error {
 	if cpus, err := cpu.Percent(0, false); err != nil {
 		res = append(res, fmt.Errorf("failed to get uptime: %s", err.Error()))
 	} else {
-		dc.pn.CpuUsed = cpus[0]
+		if dc.pn.CpuUsed = 0; len(cpus) >= 1 {
+			dc.pn.CpuUsed = cpus[0]
+		}
 	}
 	dc.pn.MemoryUsed = m.HeapAlloc / uint64(units.KiB)
 	if storage, err := dc.node.Repo.GetStorageUsage(); err != nil {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)


* **What is the current behavior?** (You can also link to an open issue here)


* **What is the new behavior?** (You can also refer to a JIRA ticket here)


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)


* **What dependencies / modules need to be updated as pre-requisites?** (Include relevant PR links here)

* **Description of changes**


---

* **Please check if the PR fulfills these requirements**
- [ ] The subject of this PR contains a JIRA ticket BTFS-xxxx (N/A for community PRs)
- [ ] PR description and commit messages are [good and meaningful](https://chris.beams.io/posts/git-commit/)
- [ ] Unit tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **Please make sure the following procedures have been applied before requesting reviewers**
- [ ] Code changes closely follow [Go Code Review Comments](https://github.com/golang/go/wiki/CodeReviewComments)
- [ ] Code has been *rebased* against latest master (`git merge` not recommended, unless you know what you are doing)
- [ ] Code changes have run through `go fmt`
- [ ] Code changes have run through `go mod tidy`
- [ ] All unit tests passed locally (`make test_go_test`)
