### PR TITLE
Fix build error where volumes() is undefined when building under FreeBSD

### DIFF
--- a/core/commands/storage/path/path_unix.go
+++ b/core/commands/storage/path/path_unix.go
@@ -1,4 +1,4 @@
-// +build linux
+// +build linux freebsd
 
 package path
 


### PR DESCRIPTION
Fix build error where volumes() is undefined when building under FreeBSD.

The build error occurs on the below line without this patch: https://github.com/TRON-US/go-btfs/blob/5e9d9b1971f7e5b1d15999bf932e03e872151fa6/core/commands/storage/path/path.go#L302